### PR TITLE
Update compiler version to 0.2.0

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-compiler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The api generated by compiler has been changed in commit 2b18b161,
but the version was forgotten to update.

This commit will fix this problem.

Signed-off-by: Tim Zhang <tim@hyper.sh>