### PR TITLE
Server: Add pub fn add_listener

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -268,6 +268,12 @@ impl Server {
         Ok(self)
     }
 
+    pub fn add_listener(mut self, fd: RawFd) -> Result<Server> {
+        self.listeners.push(fd);
+
+        Ok(self)
+    }
+
     pub fn register_service(
         mut self,
         methods: HashMap<String, Box<dyn MethodHandler + Send + Sync>>,


### PR DESCRIPTION
This commit add pub fn add_listener to Server.
This fn can add a fd as listener to Server.
Then user replaces fn add_listener with fn bind to provide more
flexibility for Server initialization.

Signed-off-by: Hui Zhu <teawater@antfin.com>