### PR TITLE
Revert "fix the issue of protobuf version mismatching issue"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/containerd/ttrpc-rust"
 description = "A Rust version of ttrpc."
 
 [dependencies]
-protobuf = { version = "=2.8.1", optional = true }
+protobuf = { version = "2.0", optional = true }
 bytes = { version = "0.4.11", optional = true }
 libc = { version = "0.2.59", features = [ "extra_traits" ] }
 nix = "0.16.1"


### PR DESCRIPTION
Since the ttrpc.rs would be auto generated by protobuf, and there is no need
to hardcode the protobuf version, so revert this commit.

This reverts commit 8345ccf5741db7ccc4209ce8df7b72ed34f52166.