### PR TITLE
server: Derive Debug trait for TtrpcContext

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -562,6 +562,7 @@ impl Server {
     }
 }
 
+#[derive(Debug)]
 pub struct TtrpcContext {
     pub fd: RawFd,
     pub mh: MessageHeader,


### PR DESCRIPTION
Add a derive attribute to make the compiler add `Debug` trait support for `TtrpcContext`. This is required to support tracing (instrumentation) for the Kata Containers rust agent, but is also a useful feature if you simply wish to print/log a context.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>