### PR TITLE
Fix feature sync actually depends on async

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -86,7 +86,7 @@ pub fn do_bind(host: &str) -> Result<RawFd> {
 macro_rules! cfg_sync {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "async")]
+            #[cfg(feature = "sync")]
             $item
         )*
     }


### PR DESCRIPTION
Feature sync previously incorrectly relied on sync.
This commit will fix this bug.

Signed-off-by: Tim Zhang <tim@hyper.sh>