### PR TITLE
Move generated file ttrpc.rs to OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,14 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
 fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let path: PathBuf = [out_dir.clone(), "mod.rs".to_string()].iter().collect();
+    fs::write(path, "pub mod ttrpc;").unwrap();
+
     protobuf_codegen_pure::Codegen::new()
-        .out_dir("src")
+        .out_dir(out_dir)
         .inputs(&["src/ttrpc.proto"])
         .include("src")
         .run()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@ pub mod error;
 #[macro_use]
 pub mod common;
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
-pub mod ttrpc;
+pub mod compiled {
+    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+}
+pub use compiled::ttrpc;
 
 pub use crate::common::MessageHeader;
 pub use crate::error::{get_status, Error, Result};


### PR DESCRIPTION
Got:
cargo publish --dry-run

error: failed to verify package tarball

Caused by:
  Source directory was modified by build.rs during cargo publish. Build scripts should not modify anything outside of OUT_DIR.
Added: /home/tim/project/ttrpc-rust/target/package/ttrpc-0.4.0/src/ttrpc.rs

This commit will resolve this issue.

Signed-off-by: Tim Zhang <tim@hyper.sh>