### PR TITLE
Set dependencies of async to optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ libc = { version = "0.2.59", features = [ "extra_traits" ] }
 nix = "0.16.1"
 log = "0.4"
 byteorder = "1.3.2"
-async-trait = "0.1.31"
 
-tokio = { version = "0.2", features = ["rt-threaded", "sync", "uds", "stream", "macros", "io-util"] }
-futures = "0.3"
-tokio-vsock = "0.2.1"
+async-trait = { version = "0.1.31", optional = true }
+tokio = { version = "0.2", features = ["rt-threaded", "sync", "uds", "stream", "macros", "io-util"], optional = true }
+futures = { version = "0.3", optional = true }
+tokio-vsock = { version = "0.2.1", optional = true }
 
 [build-dependencies]
 protobuf-codegen-pure = "2.14.0"
@@ -29,6 +29,6 @@ protobuf-codegen-pure = "2.14.0"
 [features]
 default = ["protobuf-codec", "sync"]
 protobuf-codec = ["protobuf"]
-async = []
+async = ["async-trait", "tokio", "futures", "tokio-vsock"]
 sync = []
 


### PR DESCRIPTION
Unlike in your Rust source code, we cannot use [target.'cfg(feature = "async")'.dependencies]
to add dependencies based on optional features. So we use the [features] + { optional = true } instead

Signed-off-by: Tim Zhang <tim@hyper.sh>