### PR TITLE
Fix doc.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@
 //! - `sync`: Enables traditional sync server and client (default enabled).
 //! - `protobuf-codec`: Includes rust-protobuf (default enabled).
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 #[macro_use]
 extern crate log;
 


### PR DESCRIPTION
The doc-cfg is an unstable feature, so we should use a feature flag to
turn it on.

Signed-off-by: Tim Zhang <tim@hyper.sh>