### PR TITLE
Bugfix: fix client request hang, for socket error.

### DIFF
--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -117,6 +117,15 @@ impl Client {
                     Err(x) => match x {
                         Error::Socket(y) => {
                             trace!("Socket error {}", y);
+                            let mut map = recver_map_orig.lock().unwrap();
+                            for (_, recver_tx) in map.iter_mut() {
+                                recver_tx
+                                    .send(Err(Error::Others(format!("socket error {}", y))))
+                                    .unwrap_or_else(|e| {
+                                        error!("The request has returned error {:?}", e)
+                                    });
+                            }
+                            map.clear();
                             break;
                         }
                         _ => {


### PR DESCRIPTION
If client socket get error, all the client request without timeout
will hang for client receiver thread do not return the error.

Signed-off-by: quanweiZhou <edensky01@163.com>
Signed-off-by: quanweiZhou <quanweiZhou@linux.alibaba.com>