### PR TITLE
Remove wip-check

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -27,12 +27,3 @@ jobs:
       uses: tim-actions/dco@master
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-  pr_wip_check:
-    runs-on: ubuntu-latest
-    name: WIP Check
-    steps:
-    - name: WIP Check
-      uses: tim-actions/wip-check@master
-      with:
-        labels: '["do-not-merge", "wip", "rfc"]'
-        keywords: '["WIP", "wip", "RFC", "rfc"]'


### PR DESCRIPTION
wip-check action would set commit status to failure and the commit will be marked as failure forever,
and this is not corret.

Fixes #52

Signed-off-by: Tim Zhang <tim@hyper.sh>