### PR TITLE
client: fix the issue of panic when client request timeout

### DIFF
--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -73,7 +73,10 @@ impl Client {
                     }
 
                     let e = Error::Socket(format!("{:?}", e));
-                    resp_tx.send(Err(e)).await.unwrap();
+                    resp_tx
+                        .send(Err(e))
+                        .await
+                        .unwrap_or_else(|_e| error!("The request has returned"));
 
                     break; // The stream is dead, exit the loop.
                 }
@@ -121,11 +124,11 @@ impl Client {
                                                 header, body
                                             ))))
                                             .await
-                                            .unwrap();
+                                            .unwrap_or_else(|_e| error!("The request has returned"));
                                         return;
                                     }
 
-                                    resp_tx2.send(Ok(body)).await.unwrap();
+                                    resp_tx2.send(Ok(body)).await.unwrap_or_else(|_e| error!("The request has returned"));
                                 });
                             }
                             Err(e) => {
@@ -167,7 +170,7 @@ impl Client {
                     result.ok_or_else(|| Error::Others("Recive packet from recver error".to_string()))?
                 }
                 _ = timeout => {
-                    return Err(Error::Others("Recive packet from recver error".to_string()));
+                    return Err(Error::Others("Recive packet from recver error: timeout".to_string()));
                 }
             }
         };

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -82,7 +82,9 @@ impl Client {
                         let mut map = recver_map.lock().unwrap();
                         map.remove(&current_stream_id);
                     }
-                    recver_tx.send(Err(e)).unwrap();
+                    recver_tx
+                        .send(Err(e))
+                        .unwrap_or_else(|_e| error!("The request has returned"));
                 }
             }
             trace!("Sender quit");
@@ -149,11 +151,13 @@ impl Client {
                             "Recver got malformed packet {:?} {:?}",
                             mh, buf
                         ))))
-                        .unwrap();
+                        .unwrap_or_else(|_e| error!("The request has returned"));
                     continue;
                 }
 
-                recver_tx.send(Ok(buf)).unwrap();
+                recver_tx
+                    .send(Ok(buf))
+                    .unwrap_or_else(|_e| error!("The request has returned"));
 
                 map.remove(&mh.stream_id);
             }


### PR DESCRIPTION
When the client request timeout, the client would be closed
and the receive channel would be closed, thus send to it would
get an error.

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>