### PR TITLE
ttrpc-codegen: fix protobuf customization unapplying

### DIFF
--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-codegen"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"

--- a/ttrpc-codegen/src/lib.rs
+++ b/ttrpc-codegen/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //!```
 
-use protobuf_codegen::Customize as ProtobufCustomize;
+pub use protobuf_codegen::Customize as ProtobufCustomize;
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
@@ -123,6 +123,7 @@ impl Codegen {
                 .out_dir(&self.out_dir)
                 .inputs(&self.inputs)
                 .includes(&self.includes)
+                .customize(self.rust_protobuf_customize.clone())
                 .run()
                 .expect("Gen rust protobuf failed.");
         }


### PR DESCRIPTION
Also re-export the protobuf_codegen::Customize for user convienient.

Signed-off-by: Tim Zhang <tim@hyper.sh>