### PR TITLE
Change read message error type to Error::Socket

### DIFF
--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -123,7 +123,7 @@ impl Client {
                             let mut map = recver_map_orig.lock().unwrap();
                             for (_, recver_tx) in map.iter_mut() {
                                 recver_tx
-                                    .send(Err(Error::Others(format!("socket error {}", y))))
+                                    .send(Err(Error::Socket(format!("socket error {}", y))))
                                     .unwrap_or_else(|e| {
                                         error!("The request has returned error {:?}", e)
                                     });


### PR DESCRIPTION
Change read message error type to Error::Socket

Because it's a socket error, we need to distinguish it from other errors.

Signed-off-by: quanweiZhou <quanweiZhou@linux.alibaba.com>