### PR TITLE
Graceful shutdown and server restart for async [hot upgrade needed]

### DIFF
--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -273,9 +273,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "4c30f6d0bc6b00693347368a67d41b58f2fb851215ff1da49e90fe2c5c667151"
 dependencies = [
  "libc",
 ]
@@ -447,9 +447,9 @@ checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
 name = "petgraph"
@@ -462,18 +462,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
+checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.22"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
+checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
 dependencies = [
  "proc-macro2 1.0.18",
  "quote 1.0.7",
@@ -500,9 +500,9 @@ checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"
@@ -814,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-vsock"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49825c1a1208e813509b5256ab9c05b0b57f8c71978a85d713666a5e8255cc4b"
+checksum = "547a35667d4d842422da7f5528612321770f2f640e7fd5df0431de7b717fb2b4"
 dependencies = [
  "bytes 0.4.12",
  "futures",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "ttrpc"
-version = "0.4.4"
+version = "0.4.7"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ttrpc-codegen"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use nix::unistd;
 use protobuf::{CodedInputStream, Message};
 use std::collections::HashMap;
 use std::os::unix::io::RawFd;
@@ -25,6 +26,7 @@ use tokio::{
     prelude::*,
     stream::Stream,
     sync::mpsc::{channel, Receiver, Sender},
+    sync::watch,
 };
 use tokio_vsock::VsockListener;
 
@@ -33,6 +35,9 @@ pub struct Server {
     listeners: Vec<RawFd>,
     methods: Arc<HashMap<String, Box<dyn MethodHandler + Send + Sync>>>,
     domain: Option<Domain>,
+    disconnect_tx: Option<watch::Sender<i32>>,
+    all_conn_done_rx: Option<Receiver<i32>>,
+    stop_listen_tx: Option<Sender<Sender<RawFd>>>,
 }
 
 impl Default for Server {
@@ -41,6 +46,9 @@ impl Default for Server {
             listeners: Vec::with_capacity(1),
             methods: Arc::new(HashMap::new()),
             domain: None,
+            disconnect_tx: None,
+            all_conn_done_rx: None,
+            stop_listen_tx: None,
         }
     }
 }
@@ -60,6 +68,7 @@ impl Server {
         let (fd, domain) = common::do_bind(host)?;
         self.domain = Some(domain);
 
+        common::do_listen(fd)?;
         self.listeners.push(fd);
         Ok(self)
     }
@@ -79,19 +88,17 @@ impl Server {
         self
     }
 
-    fn listen(&self) -> Result<RawFd> {
+    fn get_listenfd(&self) -> Result<RawFd> {
         if self.listeners.is_empty() {
             return Err(Error::Others("ttrpc-rust not bind".to_string()));
         }
 
-        let listenfd = self.listeners[0];
-        common::do_listen(listenfd)?;
-
+        let listenfd = self.listeners[self.listeners.len() - 1];
         Ok(listenfd)
     }
 
-    pub async fn start(&self) -> Result<()> {
-        let listenfd = self.listen()?;
+    pub async fn start(&mut self) -> Result<()> {
+        let listenfd = self.get_listenfd()?;
 
         match self.domain.as_ref().unwrap() {
             Domain::Unix => {
@@ -99,10 +106,9 @@ impl Server {
                 unsafe {
                     sys_unix_listener = SysUnixListener::from_raw_fd(listenfd);
                 }
-                let mut unix_listener = UnixListener::from_std(sys_unix_listener).unwrap();
-                let incoming = unix_listener.incoming();
+                let unix_listener = UnixListener::from_std(sys_unix_listener).unwrap();
 
-                self.do_start(listenfd, incoming).await
+                self.do_start(listenfd, unix_listener).await
             }
             Domain::Vsock => {
                 let incoming;
@@ -115,51 +121,142 @@ impl Server {
         }
     }
 
-    pub async fn do_start<I, S>(&self, listenfd: RawFd, mut incoming: I) -> Result<()>
+    pub async fn do_start<I, S>(&mut self, listenfd: RawFd, mut incoming: I) -> Result<()>
     where
-        I: Stream<Item = std::io::Result<S>> + Unpin,
+        I: Stream<Item = std::io::Result<S>> + Unpin + Send + 'static + AsRawFd,
         S: AsyncRead + AsyncWrite + AsRawFd + Send + 'static,
     {
-        while let Some(result) = incoming.next().await {
-            match result {
-                Ok(stream) => {
-                    common::set_fd_close_exec(stream.as_raw_fd())?;
-                    let methods = self.methods.clone();
-                    tokio::spawn(async move {
-                        let (mut reader, mut writer) = split(stream);
-                        let (tx, mut rx): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = channel(100);
+        let methods = self.methods.clone();
+        let (disconnect_tx, close_conn_rx) = watch::channel(0);
+        self.disconnect_tx = Some(disconnect_tx);
 
-                        tokio::spawn(async move {
-                            while let Some(buf) = rx.recv().await {
-                                if let Err(e) = writer.write_all(&buf).await {
-                                    error!("write_message got error: {:?}", e);
-                                }
-                            }
-                        });
+        let (conn_done_tx, all_conn_done_rx) = channel::<i32>(1);
 
-                        loop {
-                            let tx = tx.clone();
+        self.all_conn_done_rx = Some(all_conn_done_rx);
+        let (stop_listen_tx, mut stop_listen_rx) = channel(1);
+        self.stop_listen_tx = Some(stop_listen_tx);
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    conn = incoming.next() => {
+                        if let Some(conn) = conn {
+                            // Accept a new connection
                             let methods = methods.clone();
+                            match conn {
+                                Ok(stream) => {
+                                    let fd = stream.as_raw_fd();
+                                    if let Err(e) = common::set_fd_close_exec(fd) {
+                                        error!("{:?}", e);
+                                        continue;
+                                    }
 
-                            match receive(&mut reader).await {
-                                Ok(message) => {
+                                    let mut close_conn_rx = close_conn_rx.clone();
+
+                                    let (req_done_tx, mut all_req_done_rx) = channel::<i32>(1);
+                                    let conn_done_tx2 = conn_done_tx.clone();
+
+                                    // The connection handler
                                     tokio::spawn(async move {
-                                        handle_request(tx, listenfd, methods, message).await;
+                                        let (mut reader, mut writer) = split(stream);
+                                        let (tx, mut rx): (Sender<Vec<u8>>, Receiver<Vec<u8>>) = channel(100);
+
+                                        tokio::spawn(async move {
+                                            while let Some(buf) = rx.recv().await {
+                                                if let Err(e) = writer.write_all(&buf).await {
+                                                    error!("write_message got error: {:?}", e);
+                                                }
+                                            }
+                                        });
+
+                                        loop {
+                                            let tx = tx.clone();
+                                            let methods = methods.clone();
+                                            let req_done_tx2 = req_done_tx.clone();
+
+                                            tokio::select! {
+                                                resp = receive(&mut reader) => {
+                                                    match resp {
+                                                        Ok(message) => {
+                                                            tokio::spawn(async move {
+                                                                handle_request(tx, listenfd, methods, message).await;
+                                                                drop(req_done_tx2);
+                                                            });
+                                                        }
+                                                        Err(e) => {
+                                                            trace!("error {:?}", e);
+                                                            break;
+                                                        }
+                                                    }
+                                                }
+                                                v = close_conn_rx.recv() => {
+                                                    // 0 is the init value of this watch, not a valid signal
+                                                    // is_none means the tx was dropped.
+                                                    if v.is_none() || v.unwrap() != 0 {
+                                                        info!("Stop accepting new connections.");
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                        drop(req_done_tx);
+                                        all_req_done_rx.recv().await;
+                                        drop(conn_done_tx2);
                                     });
                                 }
                                 Err(e) => {
-                                    trace!("error {:?}", e);
-                                    break;
+                                    error!("{:?}", e)
                                 }
                             }
+
+                        } else {
+                            break;
                         }
-                    });
+                    }
+                    fd_tx = stop_listen_rx.recv() => {
+                        if let Some(mut fd_tx) = fd_tx {
+                            let dup_fd = unistd::dup(incoming.as_raw_fd()).unwrap();
+                            common::set_fd_close_exec(dup_fd).unwrap();
+                            drop(incoming);
+
+                            fd_tx.send(dup_fd).await.unwrap();
+                            break;
+                        }
+                    }
                 }
-                Err(e) => error!("{:?}", e),
             }
-        }
+            drop(conn_done_tx);
+        });
+        Ok(())
+    }
+
+    pub async fn shutdown(&mut self) -> Result<()> {
+        self.stop_listen().await;
+        self.disconnect().await;
 
         Ok(())
+    }
+
+    pub async fn disconnect(&mut self) {
+        if let Some(tx) = self.disconnect_tx.take() {
+            tx.broadcast(1).ok();
+        }
+
+        if let Some(mut rx) = self.all_conn_done_rx.take() {
+            rx.recv().await;
+        }
+    }
+
+    pub async fn stop_listen(&mut self) {
+        if let Some(mut tx) = self.stop_listen_tx.take() {
+            let (fd_tx, mut fd_rx) = channel(1);
+            tx.send(fd_tx).await.unwrap();
+
+            let fd = fd_rx.recv().await.unwrap();
+            self.listeners.clear();
+            self.listeners.push(fd);
+        }
     }
 }
 


### PR DESCRIPTION
    async: graceful shutdown and server restart supported
    
    - Support graceful shutdown.
    - Support stop_listen() -> start() to restart.
    - Examples updates
    - Implement AsRawFd and FromRawFd

    The hot upgrade needs the restart feature.
    First call stop_listen() to stop new connections coming then call
    disconnect() to wait all exist request done. if there are failures
    during stop_listen() and disconnect(), only need to call start()
    to make rollback.
    
    Signed-off-by: Tim Zhang <tim@hyper.sh>