### PR TITLE
Fix fd leakage in client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc"
-version = "0.4.10"
+version = "0.4.11"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -50,7 +50,7 @@ impl Client {
             AddressFamily::Unix,
             SockType::Stream,
             None,
-            SockFlag::empty(),
+            SockFlag::SOCK_CLOEXEC,
         )
         .unwrap();
         let client_close = Arc::new(ClientClose { fd, close_fd });
@@ -185,6 +185,9 @@ impl Client {
 
                 map.remove(&mh.stream_id);
             }
+
+            close(recver_fd).unwrap();
+
             trace!("Recver quit");
         });
 


### PR DESCRIPTION
Set close-on-exec for recver_fd, close_fd and close recver_fd after close.

Signed-off-by: Tim Zhang <tim@hyper.sh>