### PR TITLE
Log a warning when close recver_fd failed in client.

### DIFF
--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -186,7 +186,12 @@ impl Client {
                 map.remove(&mh.stream_id);
             }
 
-            close(recver_fd).unwrap();
+            let _ = close(recver_fd).map_err(|e| {
+                warn!(
+                    "failed to close recver_fd: {} with error: {:?}",
+                    recver_fd, e
+                )
+            });
 
             trace!("Recver quit");
         });


### PR DESCRIPTION
Instead panic, just leave a warning.

Signed-off-by: Tim Zhang <tim@hyper.sh>