### PR TITLE
server: fix the issue of failed to trigger client handler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc"
-version = "0.4.12"
+version = "0.4.13"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -110,7 +110,7 @@ fn start_method_handler_thread(
                 if quit.load(Ordering::SeqCst) {
                     // notify the connection dealing main thread to stop.
                     control_tx
-                        .try_send(())
+                        .send(())
                         .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
                     break;
                 }
@@ -120,15 +120,16 @@ fn start_method_handler_thread(
             if quit.load(Ordering::SeqCst) {
                 // notify the connection dealing main thread to stop.
                 control_tx
-                    .try_send(())
+                    .send(())
                     .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
                 break;
             }
 
             let c = wtc.fetch_sub(1, Ordering::SeqCst) - 1;
             if c < min {
+                trace!("notify client handler to create much more worker threads!");
                 control_tx
-                    .try_send(())
+                    .send(())
                     .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
             }
 
@@ -147,7 +148,7 @@ fn start_method_handler_thread(
                         // the connection dealing main thread would
                         // have exited.
                         control_tx
-                            .try_send(())
+                            .send(())
                             .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
                         break;
                     }
@@ -174,7 +175,7 @@ fn start_method_handler_thread(
                     // the connection dealing main thread would have
                     // exited.
                     control_tx
-                        .try_send(())
+                        .send(())
                         .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
                     break;
                 }
@@ -197,7 +198,7 @@ fn start_method_handler_thread(
                     // the connection dealing main thread would have
                     // exited.
                     control_tx
-                        .try_send(())
+                        .send(())
                         .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
                     break;
                 }
@@ -215,7 +216,7 @@ fn start_method_handler_thread(
                 // the connection dealing main thread would have
                 // exited.
                 control_tx
-                    .try_send(())
+                    .send(())
                     .unwrap_or_else(|err| debug!("Failed to try send {:?}", err));
                 break;
             }


### PR DESCRIPTION
Since the sync channel with a buffer size of 0 will
become "rendezvous channel" where a try_send would return
directly with an error when its peer receiver isn't waiting
to acquire some data, and in this case there would be chance
to miss trigger client handler to create much more worker
threads to handle the request messages.

Thus, it should use "send" to block until its peer receiver is
available to hand off the message.

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>