### PR TITLE
api: add metadata for server and client

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -212,7 +212,7 @@ impl<'a> MethodGen<'a> {
     // Method signatures
     fn unary(&self, method_name: &str) -> String {
         format!(
-            "{}(&self, req: &{}, timeout_nano: i64) -> {}<{}>",
+            "{}(&self, req: &{}, metadata: Option<HashMap<String, Vec<String>>>, timeout_nano: i64) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("Result"),
@@ -222,7 +222,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_async(&self, method_name: &str) -> String {
         format!(
-            "{}(&mut self, req: &{}, timeout_nano: i64) -> {}<{}>",
+            "{}(&mut self, req: &{}, metadata: Option<HashMap<String, Vec<String>>>, timeout_nano: i64) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("Result"),
@@ -314,7 +314,7 @@ impl<'a> MethodGen<'a> {
                         self.output()
                     ));
                     w.write_line(&format!(
-                        "::ttrpc::client_request!(self, req, timeout_nano, \"{}.{}\", \"{}\", cres);",
+                        "::ttrpc::client_request!(self, req, metadata, timeout_nano, \"{}.{}\", \"{}\", cres);",
                         self.package_name,
                         self.service_name,
                         &self.proto.get_name(),
@@ -335,7 +335,7 @@ impl<'a> MethodGen<'a> {
                 pub_async_fn(w, &self.unary_async(&method_name), |w| {
                     w.write_line(&format!("let mut cres = {}::new();", self.output()));
                     w.write_line(&format!(
-                        "::ttrpc::async_client_request!(self, req, timeout_nano, \"{}.{}\", \"{}\", cres);",
+                        "::ttrpc::async_client_request!(self, req, metadata, timeout_nano, \"{}.{}\", \"{}\", cres);",
                         self.package_name,
                         self.service_name,
                         &self.proto.get_name(),

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -212,7 +212,7 @@ impl<'a> MethodGen<'a> {
     // Method signatures
     fn unary(&self, method_name: &str) -> String {
         format!(
-            "{}(&self, req: &{}, metadata: Option<HashMap<String, Vec<String>>>, timeout_nano: i64) -> {}<{}>",
+            "{}(&self, ctx: ttrpc::context::Context, req: &{}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("Result"),
@@ -222,7 +222,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_async(&self, method_name: &str) -> String {
         format!(
-            "{}(&mut self, req: &{}, metadata: Option<HashMap<String, Vec<String>>>, timeout_nano: i64) -> {}<{}>",
+            "{}(&mut self, ctx: ttrpc::context::Context, req: &{}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("Result"),
@@ -314,7 +314,7 @@ impl<'a> MethodGen<'a> {
                         self.output()
                     ));
                     w.write_line(&format!(
-                        "::ttrpc::client_request!(self, req, metadata, timeout_nano, \"{}.{}\", \"{}\", cres);",
+                        "::ttrpc::client_request!(self, ctx, req, \"{}.{}\", \"{}\", cres);",
                         self.package_name,
                         self.service_name,
                         &self.proto.get_name(),
@@ -335,7 +335,7 @@ impl<'a> MethodGen<'a> {
                 pub_async_fn(w, &self.unary_async(&method_name), |w| {
                     w.write_line(&format!("let mut cres = {}::new();", self.output()));
                     w.write_line(&format!(
-                        "::ttrpc::async_client_request!(self, req, metadata, timeout_nano, \"{}.{}\", \"{}\", cres);",
+                        "::ttrpc::async_client_request!(self, ctx, req, \"{}.{}\", \"{}\", cres);",
                         self.package_name,
                         self.service_name,
                         &self.proto.get_name(),

--- a/example/Cargo.lock
+++ b/example/Cargo.lock
@@ -793,9 +793,7 @@ dependencies = [
 
 [[package]]
 name = "ttrpc-compiler"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30a7122ecdc9fb3d7db63a04e1066f5a1d77e0edc41e41e72e718df663f6404"
+version = "0.3.2"
 dependencies = [
  "derive-new",
  "prost",

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -43,3 +43,6 @@ path = "./async-client.rs"
 [build-dependencies]
 ttrpc-codegen = { path = "../ttrpc-codegen"}
 
+[patch.crates-io]
+ttrpc-compiler = { path = "../compiler"}
+

--- a/example/async-server.rs
+++ b/example/async-server.rs
@@ -39,12 +39,14 @@ impl health_ttrpc::Health for HealthService {
 
         Err(Error::RpcStatus(status))
     }
+
     async fn version(
         &self,
-        _ctx: &::ttrpc::r#async::TtrpcContext,
+        ctx: &::ttrpc::r#async::TtrpcContext,
         req: health::CheckRequest,
     ) -> Result<health::VersionCheckResponse> {
         info!("version {:?}", req);
+        info!("ctx {:?}", ctx);
         let mut rep = health::VersionCheckResponse::new();
         rep.agent_version = "mock.0.1".to_string();
         rep.grpc_version = "0.0.1".to_string();

--- a/example/build.rs
+++ b/example/build.rs
@@ -17,11 +17,6 @@ fn main() {
         "protocols/protos/oci.proto",
     ];
 
-    // Tell Cargo that if the .proto files changed, to rerun this build script.
-    protos
-        .iter()
-        .for_each(|p| println!("cargo:rerun-if-changed={}", &p));
-
     Codegen::new()
         .out_dir("protocols/sync")
         .inputs(&protos)

--- a/example/server.rs
+++ b/example/server.rs
@@ -38,12 +38,14 @@ impl health_ttrpc::Health for HealthService {
         status.set_message("Just for fun".to_string());
         Err(Error::RpcStatus(status))
     }
+
     fn version(
         &self,
-        _ctx: &::ttrpc::TtrpcContext,
+        ctx: &::ttrpc::TtrpcContext,
         req: health::CheckRequest,
     ) -> Result<health::VersionCheckResponse> {
         info!("version {:?}", req);
+        info!("ctx {:?}", ctx);
         let mut rep = health::VersionCheckResponse::new();
         rep.agent_version = "mock.0.1".to_string();
         rep.grpc_version = "0.0.1".to_string();
@@ -73,7 +75,6 @@ impl agent_ttrpc::AgentService for AgentService {
         i.set_Interfaces(rp);
 
         Ok(i)
-        //Err(::ttrpc::Error::RpcStatus(::ttrpc::get_Status(::ttrpc::Code::NOT_FOUND, "".to_string())))
     }
 }
 

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 use crate::asynchronous::stream::{receive, respond, respond_with_status};
 use crate::asynchronous::unix_incoming::UnixIncoming;
 use crate::common::{self, Domain, MESSAGE_TYPE_REQUEST};
+use crate::context;
 use crate::error::{get_status, Error, Result};
 use crate::r#async::{MethodHandler, TtrpcContext};
 use crate::ttrpc::{Code, Request};
@@ -310,7 +311,7 @@ async fn handle_request(
     let path = format!("/{}/{}", req.service, req.method);
     if let Some(x) = methods.get(&path) {
         let method = x;
-        let ctx = TtrpcContext { fd, mh: header, metadata: common::parse_metadata(&req.metadata) };
+        let ctx = TtrpcContext { fd, mh: header, metadata: context::from_pb(&req.metadata) };
 
         match method.handler(ctx, req).await {
             Ok((stream_id, body)) => {

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -310,7 +310,7 @@ async fn handle_request(
     let path = format!("/{}/{}", req.service, req.method);
     if let Some(x) = methods.get(&path) {
         let method = x;
-        let ctx = TtrpcContext { fd, mh: header };
+        let ctx = TtrpcContext { fd, mh: header, metadata: common::parse_metadata(&req.metadata) };
 
         match method.handler(ctx, req).await {
             Ok((stream_id, body)) => {

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -8,6 +8,7 @@ use crate::error::{Error, Result};
 use crate::ttrpc::{Request, Response};
 use async_trait::async_trait;
 use protobuf::Message;
+use std::collections::HashMap;
 use std::os::unix::io::{FromRawFd, RawFd};
 use tokio::net::UnixStream;
 
@@ -87,6 +88,7 @@ pub trait MethodHandler {
 pub struct TtrpcContext {
     pub fd: std::os::unix::io::RawFd,
     pub mh: MessageHeader,
+    pub metadata: HashMap<String, Vec<String>>,
 }
 
 pub fn convert_response_to_buf(res: Response) -> Result<Vec<u8>> {

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -54,11 +54,13 @@ macro_rules! async_request_handler {
 /// Send request through async client.
 #[macro_export]
 macro_rules! async_client_request {
-    ($self: ident, $req: ident, $timeout_nano: ident, $server: expr, $method: expr, $cres: ident) => {
+    ($self: ident, $req: ident, $metadata: ident, $timeout_nano: ident, $server: expr, $method: expr, $cres: ident) => {
         let mut creq = ::ttrpc::Request::new();
         creq.set_service($server.to_string());
         creq.set_method($method.to_string());
         creq.set_timeout_nano($timeout_nano);
+        let md = ::ttrpc::common::convert_metadata(&$metadata);
+        creq.set_metadata(md);
         creq.payload.reserve($req.compute_size() as usize);
         {
             let mut s = CodedOutputStream::vec(&mut creq.payload);

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -54,12 +54,12 @@ macro_rules! async_request_handler {
 /// Send request through async client.
 #[macro_export]
 macro_rules! async_client_request {
-    ($self: ident, $req: ident, $metadata: ident, $timeout_nano: ident, $server: expr, $method: expr, $cres: ident) => {
+    ($self: ident, $ctx: ident, $req: ident, $server: expr, $method: expr, $cres: ident) => {
         let mut creq = ::ttrpc::Request::new();
         creq.set_service($server.to_string());
         creq.set_method($method.to_string());
-        creq.set_timeout_nano($timeout_nano);
-        let md = ::ttrpc::common::convert_metadata(&$metadata);
+        creq.set_timeout_nano($ctx.timeout_nano);
+        let md = ::ttrpc::context::to_pb($ctx.metadata);
         creq.set_metadata(md);
         creq.payload.reserve($req.compute_size() as usize);
         {

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,10 +8,8 @@
 #![allow(unused_macros)]
 
 use crate::error::{Error, Result};
-use crate::ttrpc::KeyValue;
 use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
 use nix::sys::socket::*;
-use std::collections::HashMap;
 use std::os::unix::io::RawFd;
 use std::str::FromStr;
 
@@ -141,87 +139,3 @@ pub const MESSAGE_LENGTH_MAX: usize = 4 << 20;
 
 pub const MESSAGE_TYPE_REQUEST: u8 = 0x1;
 pub const MESSAGE_TYPE_RESPONSE: u8 = 0x2;
-
-pub fn parse_metadata(kvs: &protobuf::RepeatedField<KeyValue>) -> HashMap<String, Vec<String>> {
-    let mut meta: HashMap<String, Vec<String>> = HashMap::new();
-    for kv in kvs {
-        if let Some(ref mut vl) = meta.get_mut(&kv.key) {
-            vl.push(kv.value.clone());
-        } else {
-            meta.insert(kv.key.clone(), vec![kv.value.clone()]);
-        }
-    }
-    meta
-}
-
-pub fn convert_metadata(
-    kvs: &Option<HashMap<String, Vec<String>>>,
-) -> protobuf::RepeatedField<KeyValue> {
-    let mut meta: protobuf::RepeatedField<KeyValue> = protobuf::RepeatedField::default();
-    match kvs {
-        Some(kvs) => {
-            for (k, vl) in kvs {
-                for v in vl {
-                    let key = KeyValue {
-                        key: k.clone(),
-                        value: v.clone(),
-                        ..Default::default()
-                    };
-                    meta.push(key);
-                }
-            }
-        }
-        None => {}
-    }
-    meta
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{convert_metadata, parse_metadata};
-    use crate::ttrpc::KeyValue;
-
-    #[test]
-    fn test_metadata() {
-        // RepeatedField -> HashMap, test parse_metadata()
-        let mut src: protobuf::RepeatedField<KeyValue> = protobuf::RepeatedField::default();
-        for i in &[
-            ("key1", "value1-1"),
-            ("key1", "value1-2"),
-            ("key2", "value2"),
-        ] {
-            let key = KeyValue {
-                key: i.0.to_string(),
-                value: i.1.to_string(),
-                ..Default::default()
-            };
-            src.push(key);
-        }
-
-        let dst = parse_metadata(&src);
-        assert_eq!(dst.len(), 2);
-
-        assert_eq!(
-            dst.get("key1"),
-            Some(&vec!["value1-1".to_string(), "value1-2".to_string()])
-        );
-        assert_eq!(dst.get("key2"), Some(&vec!["value2".to_string()]));
-        assert_eq!(dst.get("key3"), None);
-
-        // HashMap -> RepeatedField , test convert_metadata()
-        let src = convert_metadata(&Some(dst));
-        let mut kvs = src.into_vec();
-        kvs.sort_by(|a, b| a.key.partial_cmp(&b.key).unwrap());
-
-        assert_eq!(kvs.len(), 3);
-
-        assert_eq!(kvs[0].key, "key1");
-        assert_eq!(kvs[0].value, "value1-1");
-
-        assert_eq!(kvs[1].key, "key1");
-        assert_eq!(kvs[1].value, "value1-2");
-
-        assert_eq!(kvs[2].key, "key2");
-        assert_eq!(kvs[2].value, "value2");
-    }
-}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,159 @@
+// Copyright (c) 2021 Ant group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::ttrpc::KeyValue;
+use std::collections::HashMap;
+
+#[derive(Default, Debug)]
+pub struct Context {
+    pub metadata: HashMap<String, Vec<String>>,
+    pub timeout_nano: i64,
+}
+
+pub fn with_timeout(i: i64) -> Context {
+    Context {
+        timeout_nano: i,
+        ..Default::default()
+    }
+}
+
+pub fn with_metadata(md: HashMap<String, Vec<String>>) -> Context {
+    Context {
+        metadata: md,
+        ..Default::default()
+    }
+}
+
+impl Context {
+    // appends additional values to the given key.
+    pub fn add(&mut self, key: String, value: String) {
+        if let Some(ref mut vl) = self.metadata.get_mut(&key) {
+            vl.push(value);
+        } else {
+            self.metadata.insert(key.to_lowercase(), vec![value]);
+        }
+    }
+
+    // Set sets the provided values for a given key.
+    // The values will overwrite any existing values.
+    // If no values provided, a key will be deleted.
+    pub fn set(&mut self, key: String, value: Vec<String>) {
+        if value.is_empty() {
+            self.metadata.remove(&key);
+        } else {
+            self.metadata.insert(key.to_lowercase(), value);
+        }
+    }
+}
+
+pub fn from_pb(kvs: &protobuf::RepeatedField<KeyValue>) -> HashMap<String, Vec<String>> {
+    let mut meta: HashMap<String, Vec<String>> = HashMap::new();
+    for kv in kvs {
+        if let Some(ref mut vl) = meta.get_mut(&kv.key) {
+            vl.push(kv.value.clone());
+        } else {
+            meta.insert(kv.key.clone(), vec![kv.value.clone()]);
+        }
+    }
+    meta
+}
+
+pub fn to_pb(kvs: HashMap<String, Vec<String>>) -> protobuf::RepeatedField<KeyValue> {
+    let mut meta: protobuf::RepeatedField<KeyValue> = protobuf::RepeatedField::default();
+    for (k, vl) in kvs {
+        for v in vl {
+            let key = KeyValue {
+                key: k.clone(),
+                value: v.clone(),
+                ..Default::default()
+            };
+            meta.push(key);
+        }
+    }
+    meta
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context;
+    use crate::ttrpc::KeyValue;
+
+    #[test]
+    fn test_metadata() {
+        // RepeatedField -> HashMap, test from_pb()
+        let mut src: protobuf::RepeatedField<KeyValue> = protobuf::RepeatedField::default();
+        for i in &[
+            ("key1", "value1-1"),
+            ("key1", "value1-2"),
+            ("key2", "value2"),
+        ] {
+            let key = KeyValue {
+                key: i.0.to_string(),
+                value: i.1.to_string(),
+                ..Default::default()
+            };
+            src.push(key);
+        }
+
+        let dst = context::from_pb(&src);
+        assert_eq!(dst.len(), 2);
+
+        assert_eq!(
+            dst.get("key1"),
+            Some(&vec!["value1-1".to_string(), "value1-2".to_string()])
+        );
+        assert_eq!(dst.get("key2"), Some(&vec!["value2".to_string()]));
+        assert_eq!(dst.get("key3"), None);
+
+        // HashMap -> RepeatedField , test to_pb()
+        let src = context::to_pb(dst);
+        let mut kvs = src.into_vec();
+        kvs.sort_by(|a, b| a.key.partial_cmp(&b.key).unwrap());
+
+        assert_eq!(kvs.len(), 3);
+
+        assert_eq!(kvs[0].key, "key1");
+        assert_eq!(kvs[0].value, "value1-1");
+
+        assert_eq!(kvs[1].key, "key1");
+        assert_eq!(kvs[1].value, "value1-2");
+
+        assert_eq!(kvs[2].key, "key2");
+        assert_eq!(kvs[2].value, "value2");
+    }
+
+    #[test]
+    fn test_context() {
+        let ctx: context::Context = Default::default();
+        assert_eq!(0, ctx.timeout_nano);
+        assert_eq!(ctx.metadata.len(), 0);
+
+        let mut ctx = context::with_timeout(99);
+        assert_eq!(99, ctx.timeout_nano);
+        assert_eq!(ctx.metadata.len(), 0);
+
+        ctx.add("key1".to_string(), "value1-1".to_string());
+        assert_eq!(ctx.metadata.len(), 1);
+        assert_eq!(
+            ctx.metadata.get("key1"),
+            Some(&vec!["value1-1".to_string()])
+        );
+
+        ctx.add("key1".to_string(), "value1-2".to_string());
+        assert_eq!(ctx.metadata.len(), 1);
+        assert_eq!(
+            ctx.metadata.get("key1"),
+            Some(&vec!["value1-1".to_string(), "value1-2".to_string()])
+        );
+
+        ctx.set("key2".to_string(), vec!["value2".to_string()]);
+        assert_eq!(ctx.metadata.len(), 2);
+        assert_eq!(ctx.metadata.get("key2"), Some(&vec!["value2".to_string()]));
+
+        ctx.set("key1".to_string(), vec![]);
+        assert_eq!(ctx.metadata.len(), 1);
+        assert_eq!(ctx.metadata.get("key1"), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,9 @@ mod compiled {
 pub use compiled::ttrpc;
 
 #[doc(inline)]
+pub mod context;
+
+#[doc(inline)]
 pub use crate::common::MessageHeader;
 #[doc(inline)]
 pub use crate::error::{get_status, Error, Result};

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -209,6 +209,7 @@ fn start_method_handler_thread(
                 fd,
                 mh,
                 res_tx: res_tx.clone(),
+                metadata: common::parse_metadata(&req.metadata),
             };
             if let Err(x) = method.handler(ctx, req) {
                 debug!("method handle {} get error {:?}", path, x);

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -28,6 +28,7 @@ use std::thread::JoinHandle;
 use std::{io, thread};
 
 use crate::common::{self, MESSAGE_TYPE_REQUEST};
+use crate::context;
 use crate::error::{get_status, Error, Result};
 use crate::sync::channel::{read_message, write_message};
 use crate::ttrpc::{Code, Request, Response};
@@ -209,7 +210,7 @@ fn start_method_handler_thread(
                 fd,
                 mh,
                 res_tx: res_tx.clone(),
-                metadata: common::parse_metadata(&req.metadata),
+                metadata: context::from_pb(&req.metadata),
             };
             if let Err(x) = method.handler(ctx, req) {
                 debug!("method handle {} get error {:?}", path, x);

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -70,12 +70,12 @@ macro_rules! request_handler {
 /// Send request through sync client.
 #[macro_export]
 macro_rules! client_request {
-    ($self: ident, $req: ident, $metadata: ident, $timeout_nano: ident, $server: expr, $method: expr, $cres: ident) => {
+    ($self: ident, $ctx: ident, $req: ident, $server: expr, $method: expr, $cres: ident) => {
         let mut creq = ::ttrpc::Request::new();
         creq.set_service($server.to_string());
         creq.set_method($method.to_string());
-        creq.set_timeout_nano($timeout_nano);
-        let md = ::ttrpc::common::convert_metadata(&$metadata);
+        creq.set_timeout_nano($ctx.timeout_nano);
+        let md = ::ttrpc::context::to_pb($ctx.metadata);
         creq.set_metadata(md);
         creq.payload.reserve($req.compute_size() as usize);
         let mut s = CodedOutputStream::vec(&mut creq.payload);

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -70,11 +70,13 @@ macro_rules! request_handler {
 /// Send request through sync client.
 #[macro_export]
 macro_rules! client_request {
-    ($self: ident, $req: ident, $timeout_nano: ident, $server: expr, $method: expr, $cres: ident) => {
+    ($self: ident, $req: ident, $metadata: ident, $timeout_nano: ident, $server: expr, $method: expr, $cres: ident) => {
         let mut creq = ::ttrpc::Request::new();
         creq.set_service($server.to_string());
         creq.set_method($method.to_string());
         creq.set_timeout_nano($timeout_nano);
+        let md = ::ttrpc::common::convert_metadata(&$metadata);
+        creq.set_metadata(md);
         creq.payload.reserve($req.compute_size() as usize);
         let mut s = CodedOutputStream::vec(&mut creq.payload);
         $req.write_to(&mut s)

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -7,6 +7,7 @@ use crate::common::{MessageHeader, MESSAGE_TYPE_RESPONSE};
 use crate::error::{Error, Result};
 use crate::ttrpc::{Request, Response};
 use protobuf::Message;
+use std::collections::HashMap;
 
 /// Response message through a channel.
 /// Eventually  the message will sent to Client.
@@ -94,6 +95,7 @@ pub struct TtrpcContext {
     pub fd: std::os::unix::io::RawFd,
     pub mh: MessageHeader,
     pub res_tx: std::sync::mpsc::Sender<(MessageHeader, Vec<u8>)>,
+    pub metadata: HashMap<String, Vec<String>>,
 }
 
 /// Trait that implements handler which is a proxy to the desired method (sync).

--- a/src/ttrpc.proto
+++ b/src/ttrpc.proto
@@ -21,6 +21,12 @@ message Request {
 	string method = 2;
 	bytes payload = 3;
 	int64 timeout_nano = 4;
+	repeated KeyValue metadata = 5;
+}
+
+message KeyValue {
+	string key = 1;
+	string value = 2;
 }
 
 // Get from github.com/gogo/protobuf/protobuf/google/protobuf/any.proto

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -16,4 +16,4 @@ readme = "README.md"
 protobuf = { version = "2.14.0" }
 protobuf-codegen-pure = "2.14.0"
 protobuf-codegen = "2.14.0"
-ttrpc-compiler = "0.3"
+ttrpc-compiler = "0.3.2"


### PR DESCRIPTION
For tracing purpose, it needs to pass metadata like span id to the server.
`ttrpc-rust` should then parse the metadata to service handler by `TtrpcContext`

This commit is mainly a porting of parts of `metadata_test.go`
and `types.go` if go version, and now only working on server side.

Signed-off-by: bin liu <bin@hyper.sh>