### PR TITLE
Add Clone derive for Context

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -6,7 +6,7 @@
 use crate::ttrpc::KeyValue;
 use std::collections::HashMap;
 
-#[derive(Default, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct Context {
     pub metadata: HashMap<String, Vec<String>>,
     pub timeout_nano: i64,


### PR DESCRIPTION
Users can easily use it without manually clone it.

Signed-off-by: bin <bin@hyper.sh>