### PR TITLE
Allow soft_unstable lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@ extern crate log;
 pub mod error;
 #[macro_use]
 pub mod common;
-#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+#[allow(soft_unstable, clippy::type_complexity, clippy::too_many_arguments)]
 mod compiled {
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }


### PR DESCRIPTION
The #![rustfmt::skip] we used in ttrpc.rs has been
marked as soft_unstable in rust 1.52(rust-lang/rust#82399)

So we would got a build error like
`error: custom inner attributes are unstable`

This commit will fix this issue.

Signed-off-by: Tim Zhang <tim@hyper.sh>