### PR TITLE
Bump tokio-vsock to 0.3.1 and remove hack code for it

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ thiserror = "1.0"
 async-trait = { version = "0.1.31", optional = true }
 tokio = { version = "1", features = ["rt", "sync", "io-util", "macros", "time"], optional = true }
 futures = { version = "0.3", optional = true }
-tokio-vsock = { version = "0.3", optional = true }
+tokio-vsock = { version = "0.3.1", optional = true }
 
 [build-dependencies]
 protobuf-codegen-pure = "2.14.0"

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -167,12 +167,6 @@ impl Server {
                             // Accept a new connection
                             match conn {
                                 Ok(stream) => {
-                                    let fd = stream.as_raw_fd();
-                                    if let Err(e) = common::set_fd_close_exec(fd) {
-                                        error!("{:?}", e);
-                                        continue;
-                                    }
-
                                     // spawn a connection handler, would not block
                                     spawn_connection_handler(
                                         listenfd,


### PR DESCRIPTION
tokio-vsock 0.3.1 has fixed the fd leak to child process
problem(rust-vsock/vsock-rs#15), upgrade the tokio-vsock
and remove the set-cloexec hack for the tokio-vsock stream.

Signed-off-by: Tim Zhang <tim@hyper.sh>