### PR TITLE
Add client connect

### DIFF
--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -5,28 +5,13 @@
 
 mod protocols;
 
-use nix::sys::socket::*;
 use protocols::r#async::{agent, agent_ttrpc, health, health_ttrpc};
 use ttrpc::context::{self, Context};
 use ttrpc::r#async::Client;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let path = "/tmp/1";
-
-    let fd = socket(
-        AddressFamily::Unix,
-        SockType::Stream,
-        SockFlag::empty(),
-        None,
-    )
-    .unwrap();
-    let sockaddr = path.to_owned() + &"\x00".to_string();
-    let sockaddr = UnixAddr::new_abstract(sockaddr.as_bytes()).unwrap();
-    let sockaddr = SockAddr::Unix(sockaddr);
-    connect(fd, &sockaddr).unwrap();
-
-    let c = Client::new(fd);
+    let c = Client::connect_unix("/tmp/1").unwrap();
     let mut hc = health_ttrpc::HealthClient::new(c.clone());
     let mut ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -11,7 +11,7 @@ use ttrpc::r#async::Client;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let c = Client::connect_unix("/tmp/1").unwrap();
+    let c = Client::connect("unix:///tmp/1").unwrap();
     let mut hc = health_ttrpc::HealthClient::new(c.clone());
     let mut ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/client.rs
+++ b/example/client.rs
@@ -20,7 +20,7 @@ use ttrpc::client::Client;
 use ttrpc::context::{self, Context};
 
 fn main() {
-    let c = Client::connect_unix("/tmp/1").unwrap();
+    let c = Client::connect("unix:///tmp/1").unwrap();
     let hc = health_ttrpc::HealthClient::new(c.clone());
     let ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/client.rs
+++ b/example/client.rs
@@ -14,28 +14,13 @@
 
 mod protocols;
 
-use nix::sys::socket::*;
 use protocols::sync::{agent, agent_ttrpc, health, health_ttrpc};
 use std::thread;
 use ttrpc::client::Client;
 use ttrpc::context::{self, Context};
 
 fn main() {
-    let path = "/tmp/1";
-
-    let fd = socket(
-        AddressFamily::Unix,
-        SockType::Stream,
-        SockFlag::empty(),
-        None,
-    )
-    .unwrap();
-    let sockaddr = path.to_owned() + &"\x00".to_string();
-    let sockaddr = UnixAddr::new_abstract(sockaddr.as_bytes()).unwrap();
-    let sockaddr = SockAddr::Unix(sockaddr);
-    connect(fd, &sockaddr).unwrap();
-
-    let c = Client::new(fd);
+    let c = Client::connect_unix("/tmp/1").unwrap();
     let hc = health_ttrpc::HealthClient::new(c.clone());
     let ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
-use crate::common::MESSAGE_TYPE_RESPONSE;
+use crate::common::{client_connect_unix, MESSAGE_TYPE_RESPONSE};
 use crate::error::{Error, Result};
 use crate::ttrpc::{Code, Request, Response};
 
@@ -35,6 +35,11 @@ pub struct Client {
 }
 
 impl Client {
+    pub fn connect_unix(path: &str) -> Result<Client> {
+        let fd = unsafe { client_connect_unix(path)? };
+        Ok(Self::new(fd))
+    }
+
     /// Initialize a new [`Client`].
     pub fn new(fd: RawFd) -> Client {
         let stream = utils::new_unix_stream_from_raw_fd(fd);

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
-use crate::common::{client_connect_unix, MESSAGE_TYPE_RESPONSE};
+use crate::common::{client_connect, MESSAGE_TYPE_RESPONSE};
 use crate::error::{Error, Result};
 use crate::ttrpc::{Code, Request, Response};
 
@@ -35,8 +35,8 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn connect_unix(path: &str) -> Result<Client> {
-        let fd = unsafe { client_connect_unix(path)? };
+    pub fn connect(path: &str) -> Result<Client> {
+        let fd = unsafe { client_connect(path)? };
         Ok(Self::new(fd))
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -64,7 +64,7 @@ pub fn set_fd_close_exec(fd: RawFd) -> Result<RawFd> {
     Ok(fd)
 }
 
-pub fn do_bind(host: &str) -> Result<(RawFd, Domain)> {
+fn make_socket(host: &str, cid: u32) -> Result<(RawFd, Domain, SockAddr)> {
     let (domain, hostv) = parse_host(host)?;
 
     let sockaddr: SockAddr;
@@ -92,7 +92,6 @@ pub fn do_bind(host: &str) -> Result<(RawFd, Domain)> {
                     host
                 )));
             }
-            let cid = libc::VMADDR_CID_ANY;
             let port: u32 =
                 FromStr::from_str(host_port_v[1]).expect("the vsock port is not an number");
             fd = socket(
@@ -106,24 +105,22 @@ pub fn do_bind(host: &str) -> Result<(RawFd, Domain)> {
         }
     };
 
-    setsockopt(fd, sockopt::ReusePort, &true).ok();
+    Ok((fd, domain, sockaddr))
+}
+
+pub fn do_bind(host: &str) -> Result<(RawFd, Domain)> {
+    let (fd, domain, sockaddr) = make_socket(host, libc::VMADDR_CID_ANY)?;
+
+    setsockopt(fd, sockopt::ReusePort, &true)?;
     bind(fd, &sockaddr).map_err(err_to_others_err!(e, ""))?;
 
     Ok((fd, domain))
 }
 
 /// Creates a unix socket for client.
-pub(crate) unsafe fn client_connect_unix(path: &str) -> Result<RawFd> {
-    let fd = socket(
-        AddressFamily::Unix,
-        SockType::Stream,
-        SockFlag::empty(),
-        None,
-    )?;
+pub(crate) unsafe fn client_connect(host: &str) -> Result<RawFd> {
+    let (fd, _, sockaddr) = make_socket(host, libc::VMADDR_CID_HOST)?;
 
-    let sockaddr = path.to_owned() + &"\x00".to_string();
-    let sockaddr = UnixAddr::new_abstract(sockaddr.as_bytes()).unwrap();
-    let sockaddr = SockAddr::Unix(sockaddr);
     connect(fd, &sockaddr)?;
 
     Ok(fd)

--- a/src/common.rs
+++ b/src/common.rs
@@ -112,6 +112,23 @@ pub fn do_bind(host: &str) -> Result<(RawFd, Domain)> {
     Ok((fd, domain))
 }
 
+/// Creates a unix socket for client.
+pub(crate) unsafe fn client_connect_unix(path: &str) -> Result<RawFd> {
+    let fd = socket(
+        AddressFamily::Unix,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )?;
+
+    let sockaddr = path.to_owned() + &"\x00".to_string();
+    let sockaddr = UnixAddr::new_abstract(sockaddr.as_bytes()).unwrap();
+    let sockaddr = SockAddr::Unix(sockaddr);
+    connect(fd, &sockaddr)?;
+
+    Ok(fd)
+}
+
 macro_rules! cfg_sync {
     ($($item:item)*) => {
         $(

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     #[error("rpc status: {0:?}")]
     RpcStatus(Status),
 
+    #[error("Nix error: {0}")]
+    Nix(#[from] nix::Error),
+
     #[error("ttrpc err: {0}")]
     Others(String),
 }


### PR DESCRIPTION
In current implementation `Client` must be created from `RawFd` handle.
This forces crate users to import `nix` dependency in their projects just to create a Client instance.
So this PR adds a shortcut `Client::connect(path)` to make it more user friendly.

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>