### PR TITLE
cargo: update prost dependencies

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -14,9 +14,9 @@ readme = "README.md"
 [dependencies]
 protobuf = "2.0"
 protobuf-codegen = "2.14.0"
-prost = "0.5"
-prost-build = "0.5"
-prost-types = "0.5"
+prost = "0.8"
+prost-build = "0.8"
+prost-types = "0.8"
 derive-new = "0.5"
 tempfile = "3.0"
 

--- a/compiler/src/prost_codegen.rs
+++ b/compiler/src/prost_codegen.rs
@@ -61,7 +61,7 @@ where
 
     let mut buf = Vec::new();
     fs::File::open(descriptor_set)?.read_to_end(&mut buf)?;
-    let descriptor_set = FileDescriptorSet::decode(&buf)?;
+    let descriptor_set = FileDescriptorSet::decode(&*buf)?;
 
     // Get the package names from the descriptor set.
     let mut packages: Vec<_> = descriptor_set


### PR DESCRIPTION
Let's move to version 0.8 to obtain latest fixes. cargo-audit identified
issues with the current version, including:
   RUSTSEC-2020-0002
   RUSTSEC-2021-0073

Signed-off-by: Eric Ernst <eric_ernst@apple.com>