### PR TITLE
Add timeout_nano to TtrpcContext

### DIFF
--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -316,6 +316,7 @@ async fn do_handle_request(
         fd,
         mh: header,
         metadata: context::from_pb(&req.metadata),
+        timeout_nano: req.timeout_nano,
     };
 
     let get_unknown_status_and_log_err = |e| {

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -92,6 +92,7 @@ pub struct TtrpcContext {
     pub fd: std::os::unix::io::RawFd,
     pub mh: MessageHeader,
     pub metadata: HashMap<String, Vec<String>>,
+    pub timeout_nano: i64,
 }
 
 pub fn convert_response_to_buf(res: Response) -> Result<Vec<u8>> {

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -211,6 +211,7 @@ fn start_method_handler_thread(
                 mh,
                 res_tx: res_tx.clone(),
                 metadata: context::from_pb(&req.metadata),
+                timeout_nano: req.timeout_nano,
             };
             if let Err(x) = method.handler(ctx, req) {
                 debug!("method handle {} get error {:?}", path, x);

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -98,6 +98,7 @@ pub struct TtrpcContext {
     pub mh: MessageHeader,
     pub res_tx: std::sync::mpsc::Sender<(MessageHeader, Vec<u8>)>,
     pub metadata: HashMap<String, Vec<String>>,
+    pub timeout_nano: i64,
 }
 
 /// Trait that implements handler which is a proxy to the desired method (sync).


### PR DESCRIPTION
So that server handlers could know the timeout.

Fixes: #99

Signed-off-by: Tim Zhang <tim@hyper.sh>