### PR TITLE
Support MacOS

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -3,7 +3,10 @@ on: [pull_request]
 jobs:
   make:
     name: Make
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -11,9 +14,13 @@ jobs:
         run: |
           make deps
           make
+
   clippy_check:
     name: Clippy Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
@@ -21,4 +28,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features
-
+          name: checks-${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ thiserror = "1.0"
 async-trait = { version = "0.1.31", optional = true }
 tokio = { version = "1", features = ["rt", "sync", "io-util", "macros", "time"], optional = true }
 futures = { version = "0.3", optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
 tokio-vsock = { version = "0.3.1", optional = true }
 
 [build-dependencies]

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -309,10 +309,7 @@ impl<'a> MethodGen<'a> {
             // Unary
             MethodType::Unary => {
                 w.pub_fn(&self.unary(&method_name), |w| {
-                    w.write_line(&format!(
-                        "let mut cres = {}::new();",
-                        self.output()
-                    ));
+                    w.write_line(&format!("let mut cres = {}::new();", self.output()));
                     w.write_line(&format!(
                         "::ttrpc::client_request!(self, ctx, req, \"{}.{}\", \"{}\", cres);",
                         self.package_name,

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -33,6 +33,8 @@ use tokio::{
     sync::watch,
     time::timeout,
 };
+
+#[cfg(target_os = "linux")]
 use tokio_vsock::VsockListener;
 
 /// A ttrpc Server (async).
@@ -131,15 +133,14 @@ impl Server {
 
                 self.do_start(listenfd, incoming).await
             }
+            #[cfg(target_os = "linux")]
             Some(Domain::Vsock) => {
-                let incoming;
-                unsafe {
-                    incoming = VsockListener::from_raw_fd(listenfd).incoming();
-                }
-
+                let incoming = unsafe { VsockListener::from_raw_fd(listenfd).incoming() };
                 self.do_start(listenfd, incoming).await
             }
-            _ => Err(Error::Others("Domain is not set".to_string())),
+            _ => Err(Error::Others(
+                "Domain is not set or not supported".to_string(),
+            )),
         }
     }
 

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -85,6 +85,7 @@ impl Server {
         self
     }
 
+    #[cfg(target_os = "linux")]
     pub fn set_domain_vsock(mut self) -> Self {
         self.domain = Some(Domain::Vsock);
         self

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,6 @@ use crate::error::{Error, Result};
 use nix::fcntl::{fcntl, FcntlArg, FdFlag, OFlag};
 use nix::sys::socket::*;
 use std::os::unix::io::RawFd;
-use std::str::FromStr;
 
 #[derive(Debug)]
 pub enum Domain {
@@ -109,8 +108,9 @@ fn make_socket(host: &str, cid: u32) -> Result<(RawFd, Domain, SockAddr)> {
                     host
                 )));
             }
-            let port: u32 =
-                FromStr::from_str(host_port_v[1]).expect("the vsock port is not an number");
+            let port: u32 = host_port_v[1]
+                .parse()
+                .expect("the vsock port is not an number");
             fd = socket(
                 AddressFamily::Vsock,
                 SockType::Stream,

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -16,8 +16,7 @@
 
 use nix::fcntl::OFlag;
 use nix::sys::socket::{self, *};
-use nix::unistd::close;
-use nix::unistd::pipe2;
+use nix::unistd::*;
 use protobuf::{CodedInputStream, Message};
 use std::collections::HashMap;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
@@ -330,6 +329,8 @@ impl Server {
         }
 
         self.listener_quit_flag.store(false, Ordering::SeqCst);
+
+        #[allow(deprecated)]
         let (rfd, wfd) = pipe2(OFlag::O_CLOEXEC).unwrap();
         self.monitor_fd = (rfd, wfd);
 


### PR DESCRIPTION
This PR adds MacOS support to TTRPC rust crate.

It uses conditional compilation to exclude vsock on non Linux platforms.
And another difference is that MacOS doesn't support creation of a descriptor with `CLOEXEC` atomically, so this PR adds `fcntl` calls after.

client/server example running on MacOS:

<details>

```
   Compiling ttrpc-example v0.2.0 (/Users/mxpv/Github/ttrpc-rust/example)
    Finished dev [unoptimized + debuginfo] target(s) in 4.58s
     Running `/Users/mxpv/Github/ttrpc-rust/target/debug/examples/server`
[00:00:00.000] (10d15f600) INFO   server listen started
[00:00:00.000] (10d15f600) INFO   server started
Server is running, press Ctrl + C to exit
[00:00:17.822] (700001891000) DEBUG  Got new client
[00:00:17.822] (700001e9a000) TRACE  Got Message header MessageHeader { length: 91, stream_id: 1, type_: 1, flags: 0 }
[00:00:17.822] (700001e9a000) TRACE  Got Message body [10, 17, 103, 114, 112, 99, 46, 65, 103, 101, 110, 116, 83, 101, 114, 118, 105, 99, 101, 18, 12, 79, 110, 108, 105, 110, 101, 67, 80, 85, 77, 101, 109, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 49, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 50, 42, 16, 10, 5, 107, 101, 121, 45, 50, 18, 7, 118, 97, 108, 117, 101, 45, 50]
[00:00:17.822] (70000209d000) TRACE  Got Message header MessageHeader { length: 93, stream_id: 3, type_: 1, flags: 0 }
[00:00:17.822] (700001e9a000) TRACE  Got Message request service: "grpc.AgentService" method: "OnlineCPUMem" metadata {key: "key-1" value: "value-1-1"} metadata {key: "key-1" value: "value-1-2"} metadata {key: "key-2" value: "value-2"}
[00:00:17.823] (70000209d000) TRACE  Got Message body [10, 17, 103, 114, 112, 99, 46, 65, 103, 101, 110, 116, 83, 101, 114, 118, 105, 99, 101, 18, 14, 76, 105, 115, 116, 73, 110, 116, 101, 114, 102, 97, 99, 101, 115, 42, 16, 10, 5, 107, 101, 121, 45, 50, 18, 7, 118, 97, 108, 117, 101, 45, 50, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 49, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 50]
[00:00:17.825] (700001c97000) TRACE  response thread get (MessageHeader { length: 54, stream_id: 1, type_: 2, flags: 0 }, [10, 52, 8, 5, 18, 48, 47, 103, 114, 112, 99, 46, 65, 103, 101, 110, 116, 83, 101, 114, 118, 105, 99, 101, 47, 79, 110, 108, 105, 110, 101, 67, 80, 85, 77, 101, 109, 32, 105, 115, 32, 110, 111, 116, 32, 115, 117, 112, 112, 111, 114, 116, 101, 100])
[00:00:17.826] (7000022a0000) TRACE  Got Message header MessageHeader { length: 78, stream_id: 5, type_: 1, flags: 0 }
[00:00:17.826] (70000209d000) TRACE  Got Message request service: "grpc.AgentService" method: "ListInterfaces" metadata {key: "key-2" value: "value-2"} metadata {key: "key-1" value: "value-1-1"} metadata {key: "key-1" value: "value-1-2"}
[00:00:17.826] (7000022a0000) TRACE  Got Message body [10, 11, 103, 114, 112, 99, 46, 72, 101, 97, 108, 116, 104, 18, 5, 67, 104, 101, 99, 107, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 49, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 50, 42, 16, 10, 5, 107, 101, 121, 45, 50, 18, 7, 118, 97, 108, 117, 101, 45, 50]
[00:00:17.826] (700001c97000) TRACE  response thread get (MessageHeader { length: 23, stream_id: 3, type_: 2, flags: 0 }, [10, 0, 18, 19, 10, 7, 18, 5, 102, 105, 114, 115, 116, 10, 8, 18, 6, 115, 101, 99, 111, 110, 100])
[00:00:17.826] (7000022a0000) TRACE  Got Message request service: "grpc.Health" method: "Check" metadata {key: "key-1" value: "value-1-1"} metadata {key: "key-1" value: "value-1-2"} metadata {key: "key-2" value: "value-2"}
[00:00:17.826] (700001c97000) TRACE  response thread get (MessageHeader { length: 18, stream_id: 5, type_: 2, flags: 0 }, [10, 16, 8, 5, 18, 12, 74, 117, 115, 116, 32, 102, 111, 114, 32, 102, 117, 110])
[00:00:19.828] (700001e9a000) TRACE  Got Message header MessageHeader { length: 80, stream_id: 7, type_: 1, flags: 0 }
[00:00:19.828] (700001e9a000) TRACE  Got Message body [10, 11, 103, 114, 112, 99, 46, 72, 101, 97, 108, 116, 104, 18, 7, 86, 101, 114, 115, 105, 111, 110, 42, 16, 10, 5, 107, 101, 121, 45, 50, 18, 7, 118, 97, 108, 117, 101, 45, 50, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 49, 42, 18, 10, 5, 107, 101, 121, 45, 49, 18, 9, 118, 97, 108, 117, 101, 45, 49, 45, 50]
[00:00:19.828] (700001e9a000) TRACE  Got Message request service: "grpc.Health" method: "Version" metadata {key: "key-2" value: "value-2"} metadata {key: "key-1" value: "value-1-1"} metadata {key: "key-1" value: "value-1-2"}
[00:00:19.828] (700001e9a000) INFO   version
[00:00:19.828] (700001e9a000) INFO   ctx TtrpcContext { fd: 8, mh: MessageHeader { length: 80, stream_id: 7, type_: 1, flags: 0 }, res_tx: Sender { .. }, metadata: {"key-1": ["value-1-1", "value-1-2"], "key-2": ["value-2"]}, timeout_nano: 0 }
[00:00:19.828] (700001c97000) TRACE  response thread get (MessageHeader { length: 21, stream_id: 7, type_: 2, flags: 0 }, [10, 0, 18, 17, 10, 5, 48, 46, 48, 46, 49, 18, 8, 109, 111, 99, 107, 46, 48, 46, 49])
[00:00:19.836] (70000209d000) TRACE  Socket error socket disconnected
[00:00:19.836] (70000209d000) TRACE  Socket error send control_tx
[00:00:19.836] (7000022a0000) DEBUG  Failed to send SendError { .. }
[00:00:19.836] (700001e9a000) DEBUG  Failed to send SendError { .. }
[00:00:19.836] (700001c97000) TRACE  response thread quit
[00:00:19.836] (700001891000) DEBUG  client thread quit


   Compiling ttrpc-example v0.2.0 (/Users/mxpv/Github/ttrpc-rust/example)
    Finished dev [unoptimized + debuginfo] target(s) in 2.62s
     Running `/Users/mxpv/Github/ttrpc-rust/target/debug/examples/client`
Main OS Thread - agent.online_cpu_mem() started: 27.313µs
OS Thread ThreadId(4) - health.check() started: 47.316µs
OS Thread ThreadId(5) - agent.list_interfaces() started: 67.736µs
Main OS Thread - agent.online_cpu_mem() -> RpcStatus(code: NOT_FOUND message: "/grpc.AgentService/OnlineCPUMem is not supported") ended: 4.485696ms

sleep 2 seconds ...

OS Thread ThreadId(4) - health.check() -> Err(RpcStatus(code: NOT_FOUND message: "Just for fun")) ended: 4.629423ms
OS Thread ThreadId(5) - agent.list_interfaces() -> Interfaces {name: "first"} Interfaces {name: "second"} ended: 5.419261ms
Main OS Thread - health.version() started: 2.005767967s
Main OS Thread - health.version() -> Ok(grpc_version: "0.0.1" agent_version: "mock.0.1") ended: 2.014094586s
```

</details>

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>