### PR TITLE
[release/0.4] sync/server: close conn fd in the reaper thread

### DIFF
--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -350,7 +350,10 @@ impl Server {
                                 .unwrap()
                                 .remove(&fd)
                                 .map(|mut cn| {
-                                    cn.handler.take().map(|handler| handler.join().unwrap())
+                                    cn.handler.take().map(|handler| {
+                                        handler.join().unwrap();
+                                        close(fd).unwrap();
+                                    })
                                 });
                         }
                         info!("reaper thread exited");
@@ -478,7 +481,8 @@ impl Server {
                             // drop the res_tx, thus the res_rx would get terminated notification.
                             drop(res_tx);
                             handler.join().unwrap_or(());
-                            close(fd).unwrap_or(());
+                            // client_handler should not close fd before exit
+                            // , which prevent fd reuse issue.
                             reaper_tx_child.send(fd).unwrap();
 
                             debug!("client thread quit");


### PR DESCRIPTION
The sync/server uses accepted fd as key to maintain the connection and
closes the fd before client_handler thread exits. It will cause the
deadlock between listen and reaper threads. The timeline is like:

```
reaper			listener			client-handler-1

							close(fd=100)

			fd(=100)=accepted

			start client_handler-2

			locked key-values
			update (100, client_handler-2)
			unlocked

							notify reaper fd=100

received fd=100
locked key-values
wait-client_handler-2
							exit(0)

			fd(=101)=accepted
			acquiring lock
```

The lowest fd will be returned by accepted. The listener thread will use
new connection handler to replace the existing one. Since there is
long-running connection for container lifecycle, the reaper thread holds
the lock which listener thread is acquiring. It is deadlock.

To fix this issue, we should close fd in the reaper thread to prevent
the reuse fd.

Signed-off-by: Wei Fu <fuweid89@gmail.com>
(cherry picked from commit db3639c2669ceb29eee83c2954a97855f7243abb)
Signed-off-by: Wei Fu <fuweid89@gmail.com>