### PR TITLE
cargo: Update nix crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A Rust version of ttrpc."
 protobuf = { version = "2.0", optional = true }
 bytes = { version = "0.4.11", optional = true }
 libc = { version = "0.2.59", features = [ "extra_traits" ] }
-nix = "0.20.2"
+nix = "0.23.0"
 log = "0.4"
 byteorder = "1.3.2"
 thiserror = "1.0"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2.79"
 byteorder = "1.3.2"
 log = "0.4.6"
 simple-logging = "2.0.2"
-nix = "0.20.2"
+nix = "0.23.0"
 ttrpc = { path = "../", features = ["async"] }
 ctrlc = { version = "3.0", features = ["termination"] }
 tokio = { version = "1.0.1", features = ["signal", "time"] }

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -22,8 +22,8 @@ use crate::ttrpc::Code;
 use crate::MessageHeader;
 
 fn retryable(e: nix::Error) -> bool {
-    use ::nix::{errno::Errno, Error};
-    e == Error::from_errno(Errno::EINTR) || e == Error::from_errno(Errno::EAGAIN)
+    use ::nix::Error;
+    e == Error::EINTR || e == Error::EAGAIN
 }
 
 fn read_count(fd: RawFd, count: usize) -> Result<Vec<u8>> {


### PR DESCRIPTION
Updated the `nix` crate to the latest version as this allows `errno`
handling to be simplified.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>