### PR TITLE
release ttrpc-compiler v0.4.1

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-compiler"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Bump ttrpc-compiler from 0.4.0 to 0.4.1
to fix RUSTSEC-2020-0002, RUSTSEC-2021-0073

Fixes: #113 

Signed-off-by: Tim Zhang <tim@hyper.sh>