### PR TITLE
Allow concurrent usage of the asynchronous Client (part 2/2)

### DIFF
--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -12,11 +12,11 @@ use ttrpc::r#async::Client;
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = Client::connect("unix:///tmp/1").unwrap();
-    let mut hc = health_ttrpc::HealthClient::new(c.clone());
-    let mut ac = agent_ttrpc::AgentServiceClient::new(c);
+    let hc = health_ttrpc::HealthClient::new(c.clone());
+    let ac = agent_ttrpc::AgentServiceClient::new(c);
 
-    let mut thc = hc.clone();
-    let mut tac = ac.clone();
+    let thc = hc.clone();
+    let tac = ac.clone();
 
     let now = std::time::Instant::now();
 

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -147,7 +147,7 @@ impl Client {
         Client { req_tx }
     }
 
-    pub async fn request(&mut self, req: Request) -> Result<Response> {
+    pub async fn request(&self, req: Request) -> Result<Response> {
         let mut buf = Vec::with_capacity(req.compute_size() as usize);
         {
             let mut s = CodedOutputStream::vec(&mut buf);


### PR DESCRIPTION
Currently, the `request()` method of `ttrpc::r#async::Client` takes an `&mut self`. This prevents the `Client` from being used concurrently, since a mutable reference in Rust indicates (and enforces) exclusive use of an object.

In this patch, we change the signature of `request()` to take `&self` instead of `&mut self`. This allows multiple coroutines to issue concurrent RPC requests via the same `Client` object (e.g. by using an `Arc`), without breaking the API compatibility (although most of existing code will generate a warning indicating that a `let mut` is unnecessary).

We see (in the example code) that this problem is currently worked around by cloning the `Client`. However, we still hope to propose this patch, since by avoiding cloning the `Client`, we could improve the performance in scenarios where the `Client` is already wrapped in an `Arc`.

Meanwhile, the synchronized flavor of this library already takes `&self` in the `request()` method: https://github.com/containerd/ttrpc-rust/blob/dfae1ad06ec29d93ed76dfcf3e931168cd1d426a/src/sync/client.rs#L216

Therefore, by applying this patch, we maintain the consistency between the synchronized and asynchronized APIs.

(UPDATE: changes in the compiler part has been moved to a sub-PR #123.)