### PR TITLE
crate: add doc for socket address

### DIFF
--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -35,8 +35,8 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn connect(path: &str) -> Result<Client> {
-        let fd = unsafe { client_connect(path)? };
+    pub fn connect(sockaddr: &str) -> Result<Client> {
+        let fd = unsafe { client_connect(sockaddr)? };
         Ok(Self::new(fd))
     }
 

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -65,14 +65,14 @@ impl Server {
         Server::default()
     }
 
-    pub fn bind(mut self, host: &str) -> Result<Self> {
+    pub fn bind(mut self, sockaddr: &str) -> Result<Self> {
         if !self.listeners.is_empty() {
             return Err(Error::Others(
-                "ttrpc-rust just support 1 host now".to_string(),
+                "ttrpc-rust just support 1 sockaddr now".to_string(),
             ));
         }
 
-        let (fd, domain) = common::do_bind(host)?;
+        let (fd, domain) = common::do_bind(sockaddr)?;
         self.domain = Some(domain);
 
         common::do_listen(fd)?;

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -21,7 +21,7 @@ macro_rules! async_request_handler {
         {
             let mut s = CodedInputStream::from_bytes(&$req.payload);
             req.merge_from(&mut s)
-                .map_err(::ttrpc::Err_to_Others!(e, ""))?;
+                .map_err(::ttrpc::err_to_others!(e, ""))?;
         }
 
         let mut res = ::ttrpc::Response::new();
@@ -31,8 +31,8 @@ macro_rules! async_request_handler {
                 res.payload.reserve(rep.compute_size() as usize);
                 let mut s = protobuf::CodedOutputStream::vec(&mut res.payload);
                 rep.write_to(&mut s)
-                    .map_err(::ttrpc::Err_to_Others!(e, ""))?;
-                s.flush().map_err(::ttrpc::Err_to_Others!(e, ""))?;
+                    .map_err(::ttrpc::err_to_others!(e, ""))?;
+                s.flush().map_err(::ttrpc::err_to_others!(e, ""))?;
             }
             Err(x) => match x {
                 ::ttrpc::Error::RpcStatus(s) => {
@@ -66,15 +66,15 @@ macro_rules! async_client_request {
         {
             let mut s = CodedOutputStream::vec(&mut creq.payload);
             $req.write_to(&mut s)
-                .map_err(::ttrpc::Err_to_Others!(e, ""))?;
-            s.flush().map_err(::ttrpc::Err_to_Others!(e, ""))?;
+                .map_err(::ttrpc::err_to_others!(e, ""))?;
+            s.flush().map_err(::ttrpc::err_to_others!(e, ""))?;
         }
 
         let res = $self.client.request(creq).await?;
         let mut s = CodedInputStream::from_bytes(&res.payload);
         $cres
             .merge_from(&mut s)
-            .map_err(::ttrpc::Err_to_Others!(e, "Unpack get error "))?;
+            .map_err(::ttrpc::err_to_others!(e, "Unpack get error "))?;
 
         return Ok($cres);
     };

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,7 @@ macro_rules! err_to_others_err {
 
 /// Convert to ttrpc::Error::Others.
 #[macro_export]
-macro_rules! Err_to_Others {
+macro_rules! err_to_others {
     ($e: ident, $s: expr) => {
         |$e| ::ttrpc::Error::Others($s.to_string() + &$e.to_string())
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,19 @@
 //! - `async`: Enables async server and client.
 //! - `sync`: Enables traditional sync server and client (default enabled).
 //! - `protobuf-codec`: Includes rust-protobuf (default enabled).
+//!
+//! # Socket address
+//!
+//! For Linux distributions, ttrpc-rust supports three types of socket:
+//!
+//! - `unix:///run/some.sock`: Normal Unix domain socket.
+//! - `unix://@/run/some.sock`: Abstract Unix domain socket.
+//! - `vsock://vsock://8:1024`: [vsock](https://man7.org/linux/man-pages/man7/vsock.7.html).
+//!
+//! For mscOS, ttrpc-rust **only** supports normal Unix domain socket:
+//!
+//! - `unix:///run/some.sock`: Normal Unix domain socket.
+//!
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -44,8 +44,8 @@ pub struct Client {
 }
 
 impl Client {
-    pub fn connect(path: &str) -> Result<Client> {
-        let fd = unsafe { client_connect(path)? };
+    pub fn connect(sockaddr: &str) -> Result<Client> {
+        let fd = unsafe { client_connect(sockaddr)? };
         Ok(Self::new(fd))
     }
 

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -276,14 +276,14 @@ impl Server {
         Server::default()
     }
 
-    pub fn bind(mut self, host: &str) -> Result<Server> {
+    pub fn bind(mut self, sockaddr: &str) -> Result<Server> {
         if !self.listeners.is_empty() {
             return Err(Error::Others(
-                "ttrpc-rust just support 1 host now".to_string(),
+                "ttrpc-rust just support 1 sockaddr now".to_string(),
             ));
         }
 
-        let (fd, _) = common::do_bind(host)?;
+        let (fd, _) = common::do_bind(sockaddr)?;
         common::do_listen(fd)?;
 
         self.listeners.push(fd);

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -39,7 +39,7 @@ macro_rules! request_handler {
         let mut s = CodedInputStream::from_bytes(&$req.payload);
         let mut req = super::$server::$req_type::new();
         req.merge_from(&mut s)
-            .map_err(::ttrpc::Err_to_Others!(e, ""))?;
+            .map_err(::ttrpc::err_to_others!(e, ""))?;
 
         let mut res = ::ttrpc::Response::new();
         match $class.service.$req_fn(&$ctx, req) {
@@ -48,8 +48,8 @@ macro_rules! request_handler {
                 res.payload.reserve(rep.compute_size() as usize);
                 let mut s = protobuf::CodedOutputStream::vec(&mut res.payload);
                 rep.write_to(&mut s)
-                    .map_err(::ttrpc::Err_to_Others!(e, ""))?;
-                s.flush().map_err(::ttrpc::Err_to_Others!(e, ""))?;
+                    .map_err(::ttrpc::err_to_others!(e, ""))?;
+                s.flush().map_err(::ttrpc::err_to_others!(e, ""))?;
             }
             Err(x) => match x {
                 ::ttrpc::Error::RpcStatus(s) => {
@@ -80,14 +80,14 @@ macro_rules! client_request {
         creq.payload.reserve($req.compute_size() as usize);
         let mut s = CodedOutputStream::vec(&mut creq.payload);
         $req.write_to(&mut s)
-            .map_err(::ttrpc::Err_to_Others!(e, ""))?;
-        s.flush().map_err(::ttrpc::Err_to_Others!(e, ""))?;
+            .map_err(::ttrpc::err_to_others!(e, ""))?;
+        s.flush().map_err(::ttrpc::err_to_others!(e, ""))?;
 
         let res = $self.client.request(creq)?;
         let mut s = CodedInputStream::from_bytes(&res.payload);
         $cres
             .merge_from(&mut s)
-            .map_err(::ttrpc::Err_to_Others!(e, "Unpack get error "))?;
+            .map_err(::ttrpc::err_to_others!(e, "Unpack get error "))?;
     };
 }
 

--- a/ttrpc-codegen/README.md
+++ b/ttrpc-codegen/README.md
@@ -48,6 +48,6 @@ ttrpc-codegen = "0.2"
 
 ## Alternative
 The alternative is to use
-[protoc-rust crate](https://github.com/stepancheg/rust-protobuf/tree/master/protoc-rust),
+[protoc-rust crate](https://github.com/stepancheg/rust-protobuf),
 which relies on `protoc` command to parse descriptors. Both crates should produce the same result,
 otherwise please file a bug report.


### PR DESCRIPTION
This commit add doc for soket address, and change function
parameters from host/path to sockaddr.

Also make some unnecessary functions from public to private.

Signed-off-by: bin liu <bin@hyper.sh>