### PR TITLE
0.6.0-prepare: remove feature flag protobuf-codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/containerd/ttrpc-rust"
 description = "A Rust version of ttrpc."
 
 [dependencies]
-protobuf = { version = "2.0", optional = true }
+protobuf = { version = "2.0" }
 bytes = { version = "0.4.11", optional = true }
 libc = { version = "0.2.59", features = [ "extra_traits" ] }
 nix = "0.20.2"
@@ -30,8 +30,7 @@ tokio-vsock = { version = "0.3.1", optional = true }
 protobuf-codegen-pure = "2.14.0"
 
 [features]
-default = ["protobuf-codec", "sync"]
-protobuf-codec = ["protobuf"]
+default = ["sync"]
 async = ["async-trait", "tokio", "futures", "tokio-vsock"]
 sync = []
 


### PR DESCRIPTION
The dependency protobuf is required for ttrpc now. so the
feature flag protobuf-codec is useless.

Signed-off-by: Tim Zhang <tim@hyper.sh>