### PR TITLE
ttrpc-compiler: release v0.5.0

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-compiler"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -10,5 +10,6 @@ generate rust version ttrpc code from proto files.
 ## Versions
 | ttrpc-compiler version | ttrpc version |
 | ------------- | ------------- |
-| 0.3.x | <= 0.4.x  |
-| 0.4.x  | >= 0.5.x
+| 0.3.x | <= 0.4.x |
+| 0.4.x | = 0.5.x  |
+| 0.5.x | >= 0.6.x |


### PR DESCRIPTION
Release ttrpc-compiler 0.5.0

We need bump the major version because of #123

Signed-off-by: Tim Zhang <tim@hyper.sh>