### PR TITLE
ttrpc-codegen: release v0.3.0

### DIFF
--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-codegen"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"
@@ -16,4 +16,4 @@ readme = "README.md"
 protobuf = { version = "2.14.0" }
 protobuf-codegen-pure = "2.14.0"
 protobuf-codegen = "2.14.0"
-ttrpc-compiler = "0.4.0"
+ttrpc-compiler = "0.5.0"

--- a/ttrpc-codegen/README.md
+++ b/ttrpc-codegen/README.md
@@ -44,7 +44,8 @@ ttrpc-codegen = "0.2"
 | ttrpc-codegen version | ttrpc version |
 | ------------- | ------------- |
 | 0.1.x | <= 0.4.x  |
-| 0.2.x  | >= 0.5.x  |
+| 0.2.x | >= 0.5.x  |
+| 0.3.x | >= 0.6.x  |
 
 ## Alternative
 The alternative is to use


### PR DESCRIPTION
Release ttrpc-codegen 0.3.0 to bump
ttrpc-compiler from 0.4.0 to 0.5.0

Signed-off-by: Tim Zhang <tim@hyper.sh>