### PR TITLE
example: Use new domain socket protocol of ttrpc

### DIFF
--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -11,7 +11,7 @@ use ttrpc::r#async::Client;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let c = Client::connect("unix:///tmp/1").unwrap();
+    let c = Client::connect("unix://@/tmp/1").unwrap();
     let hc = health_ttrpc::HealthClient::new(c.clone());
     let ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/async-server.rs
+++ b/example/async-server.rs
@@ -94,7 +94,7 @@ async fn main() {
     let aservice = agent_ttrpc::create_agent_service(a);
 
     let mut server = Server::new()
-        .bind("unix:///tmp/1")
+        .bind("unix://@/tmp/1")
         .unwrap()
         .register_service(hservice)
         .register_service(aservice);

--- a/example/client.rs
+++ b/example/client.rs
@@ -20,7 +20,7 @@ use ttrpc::client::Client;
 use ttrpc::context::{self, Context};
 
 fn main() {
-    let c = Client::connect("unix:///tmp/1").unwrap();
+    let c = Client::connect("unix://@/tmp/1").unwrap();
     let hc = health_ttrpc::HealthClient::new(c.clone());
     let ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/server.rs
+++ b/example/server.rs
@@ -90,7 +90,7 @@ fn main() {
     let aservice = agent_ttrpc::create_agent_service(a);
 
     let mut server = Server::new()
-        .bind("unix:///tmp/1")
+        .bind("unix://@/tmp/1")
         .unwrap()
         .register_service(hservice)
         .register_service(aservice);


### PR DESCRIPTION
In #116, we update the protocol of socket path to

- vsock://xxx:xx -> Vsock
- unix:///run/aaa.sock -> normal Unix domain sock
- unix://@/run/abc.sock -> abstract Unix sock
- other:///run/d.sock -> error

In the example we use abstract socket, so we should
update the address "unix:///tmp/1" to "unix://@/tmp/1".

Signed-off-by: Tim Zhang <tim@hyper.sh>