### PR TITLE
example: use path socket address to support macOS

### DIFF
--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -4,6 +4,7 @@
 //
 
 mod protocols;
+mod utils;
 
 use protocols::r#async::{agent, agent_ttrpc, health, health_ttrpc};
 use ttrpc::context::{self, Context};
@@ -11,7 +12,7 @@ use ttrpc::r#async::Client;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    let c = Client::connect("unix://@/tmp/1").unwrap();
+    let c = Client::connect(utils::SOCK_ADDR).unwrap();
     let hc = health_ttrpc::HealthClient::new(c.clone());
     let ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/async-server.rs
+++ b/example/async-server.rs
@@ -4,6 +4,7 @@
 //
 
 mod protocols;
+mod utils;
 
 #[macro_use]
 extern crate log;
@@ -93,8 +94,10 @@ async fn main() {
     let a = Arc::new(a);
     let aservice = agent_ttrpc::create_agent_service(a);
 
+    utils::remove_if_sock_exist(utils::SOCK_ADDR).unwrap();
+
     let mut server = Server::new()
-        .bind("unix://@/tmp/1")
+        .bind(utils::SOCK_ADDR)
         .unwrap()
         .register_service(hservice)
         .register_service(aservice);

--- a/example/client.rs
+++ b/example/client.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod protocols;
+mod utils;
 
 use protocols::sync::{agent, agent_ttrpc, health, health_ttrpc};
 use std::thread;
@@ -20,7 +21,7 @@ use ttrpc::context::{self, Context};
 use ttrpc::Client;
 
 fn main() {
-    let c = Client::connect("unix://@/tmp/1").unwrap();
+    let c = Client::connect(utils::SOCK_ADDR).unwrap();
     let hc = health_ttrpc::HealthClient::new(c.clone());
     let ac = agent_ttrpc::AgentServiceClient::new(c);
 

--- a/example/server.rs
+++ b/example/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 mod protocols;
+mod utils;
 
 #[macro_use]
 extern crate log;
@@ -89,8 +90,9 @@ fn main() {
     let a = Arc::new(a);
     let aservice = agent_ttrpc::create_agent_service(a);
 
+    utils::remove_if_sock_exist(utils::SOCK_ADDR).unwrap();
     let mut server = Server::new()
-        .bind("unix://@/tmp/1")
+        .bind(utils::SOCK_ADDR)
         .unwrap()
         .register_service(hservice)
         .register_service(aservice);

--- a/example/utils.rs
+++ b/example/utils.rs
@@ -1,0 +1,18 @@
+#![allow(dead_code)]
+use std::fs;
+use std::io::Result;
+use std::path::Path;
+
+pub const SOCK_ADDR: &str = "unix:///tmp/ttrpc-test";
+
+pub fn remove_if_sock_exist(sock_addr: &str) -> Result<()> {
+    let path = sock_addr
+        .strip_prefix("unix://")
+        .expect("socket address is not expected");
+
+    if Path::new(path).exists() {
+        fs::remove_file(&path)?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Because macOS does not support abstract unix socket address.

Signed-off-by: Tim Zhang <tim@hyper.sh>