### PR TITLE
Improve handling of socket errors in the async client

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ use std::result;
 use thiserror::Error;
 
 /// The error type for ttrpc.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum Error {
     #[error("socket err: {0}")]
     Socket(String),


### PR DESCRIPTION
Previously, socket errors (such as connection reset or early EOF) were not properly handled in `ttrpc::r#async::Client`: https://github.com/containerd/ttrpc-rust/blob/e5a5373ca13270b608457944be231ccc71adf756/src/asynchronous/client.rs#L137-L140

If such errors were occurred during an RPC, the resources associated with the RPC (i.e. its sender channel) will become leaked (i.e. never being used or dropped), causing the RPC to hang forever, which is not what we want in an erroneous condition.

This patch tries to properly deliver socket errors to all pending RPC callers, as well as add some log messages useful for debugging.

Note that there are some side effects caused by this patch:

1. The `ttrpc::Error` type now becomes `Clone`able, since we want to deliver the error to all pending RPC requests (instead of only one of them).
2. The `ttrpc::r#async::Client` now uses `tokio::sync::Mutex` (instead of `std::sync::Mutex`) for mutexes, which ~works better with coroutines, as well as~ allows the `MutexGuard` type to be used across `await`s (the `std::sync::MutexGuard` is not `Send`), but is slightly heavier than `std::sync::Mutex` according to [tokio's docs](https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#which-kind-of-mutex-should-you-use).

I'm not 100% sure this patch is the best way to solve the problem, so all feedbacks are welcome.