### PR TITLE
Improve MessageHeader parsing.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,12 +59,6 @@ pub fn sock_error_msg(size: usize, msg: String) -> Error {
     get_rpc_status(Code::INVALID_ARGUMENT, msg)
 }
 
-macro_rules! err_to_rpc_err {
-    ($c: expr, $e: ident, $s: expr) => {
-        |$e| get_rpc_status($c, $s.to_string() + &$e.to_string())
-    };
-}
-
 macro_rules! err_to_others_err {
     ($e: ident, $s: expr) => {
         |$e| Error::Others($s.to_string() + &$e.to_string())


### PR DESCRIPTION
Now aync/async can use the same code to parse MessageHeader.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>