### PR TITLE
deps: remove unused crate bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ description = "A Rust version of ttrpc."
 
 [dependencies]
 protobuf = { version = "2.0" }
-bytes = { version = "0.4.11", optional = true }
 libc = { version = "0.2.59", features = [ "extra_traits" ] }
 nix = "0.23.0"
 log = "0.4"


### PR DESCRIPTION
It's no longer used.

Signed-off-by: Tim Zhang <tim@hyper.sh>