### PR TITLE
Streaming support.

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,7 @@ unlicensed = "deny"
 allow = [
     "MIT",
     "Apache-2.0",
+    "Unicode-DFS-2016",
     #"Apache-2.0 WITH LLVM-exception",
 ]
 # List of explictly disallowed licenses

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -22,6 +22,7 @@ ttrpc = { path = "../", features = ["async"] }
 ctrlc = { version = "3.0", features = ["termination"] }
 tokio = { version = "1.0.1", features = ["signal", "time"] }
 async-trait = "0.1.42"
+rand = "0.8.5"
 
 
 [[example]]
@@ -39,6 +40,14 @@ path = "./async-server.rs"
 [[example]]
 name = "async-client"
 path = "./async-client.rs"
+
+[[example]]
+name = "async-stream-server"
+path = "./async-stream-server.rs"
+
+[[example]]
+name = "async-stream-client"
+path = "./async-stream-client.rs"
 
 [build-dependencies]
 ttrpc-codegen = { path = "../ttrpc-codegen"}

--- a/example/Makefile
+++ b/example/Makefile
@@ -8,6 +8,8 @@ build:
 	cargo build --example client
 	cargo build --example async-server
 	cargo build --example async-client
+	cargo build --example async-stream-server
+	cargo build --example async-stream-client
 
 .PHONY: deps
 deps:

--- a/example/async-stream-client.rs
+++ b/example/async-stream-client.rs
@@ -1,0 +1,174 @@
+// Copyright 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+mod protocols;
+mod utils;
+
+use protocols::r#async::{empty, streaming, streaming_ttrpc};
+use ttrpc::context::{self, Context};
+use ttrpc::r#async::Client;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    simple_logging::log_to_stderr(log::LevelFilter::Info);
+
+    let c = Client::connect(utils::SOCK_ADDR).unwrap();
+    let sc = streaming_ttrpc::StreamingClient::new(c);
+
+    let _now = std::time::Instant::now();
+
+    let sc1 = sc.clone();
+    let t1 = tokio::spawn(echo_request(sc1));
+
+    let sc1 = sc.clone();
+    let t2 = tokio::spawn(echo_stream(sc1));
+
+    let sc1 = sc.clone();
+    let t3 = tokio::spawn(sum_stream(sc1));
+
+    let sc1 = sc.clone();
+    let t4 = tokio::spawn(divide_stream(sc1));
+
+    let sc1 = sc.clone();
+    let t5 = tokio::spawn(echo_null(sc1));
+
+    let t6 = tokio::spawn(echo_null_stream(sc));
+
+    let _ = tokio::join!(t1, t2, t3, t4, t5, t6);
+}
+
+fn default_ctx() -> Context {
+    let mut ctx = context::with_timeout(0);
+    ctx.add("key-1".to_string(), "value-1-1".to_string());
+    ctx.add("key-1".to_string(), "value-1-2".to_string());
+    ctx.set("key-2".to_string(), vec!["value-2".to_string()]);
+
+    ctx
+}
+
+async fn echo_request(cli: streaming_ttrpc::StreamingClient) {
+    let echo1 = streaming::EchoPayload {
+        seq: 1,
+        msg: "Echo Me".to_string(),
+        ..Default::default()
+    };
+    let resp = cli.echo(default_ctx(), &echo1).await.unwrap();
+    assert_eq!(resp.msg, echo1.msg);
+    assert_eq!(resp.seq, echo1.seq + 1);
+}
+
+async fn echo_stream(cli: streaming_ttrpc::StreamingClient) {
+    let mut stream = cli.echo_stream(default_ctx()).await.unwrap();
+
+    let mut i = 0;
+    while i < 100 {
+        let echo = streaming::EchoPayload {
+            seq: i as u32,
+            msg: format!("{}: Echo in a stream", i),
+            ..Default::default()
+        };
+        stream.send(&echo).await.unwrap();
+        let resp = stream.recv().await.unwrap();
+        assert_eq!(resp.msg, echo.msg);
+        assert_eq!(resp.seq, echo.seq + 1);
+
+        i += 2;
+    }
+    stream.close_send().await.unwrap();
+    let ret = stream.recv().await;
+    assert!(matches!(ret, Err(ttrpc::Error::Eof)));
+}
+
+async fn sum_stream(cli: streaming_ttrpc::StreamingClient) {
+    let mut stream = cli.sum_stream(default_ctx()).await.unwrap();
+
+    let mut sum = streaming::Sum::new();
+    stream.send(&streaming::Part::new()).await.unwrap();
+
+    sum.num += 1;
+    let mut i = -99i32;
+    while i <= 100 {
+        let addi = streaming::Part {
+            add: i,
+            ..Default::default()
+        };
+        stream.send(&addi).await.unwrap();
+        sum.sum += i;
+        sum.num += 1;
+
+        i += 1;
+    }
+    stream.send(&streaming::Part::new()).await.unwrap();
+    sum.num += 1;
+
+    let ssum = stream.close_and_recv().await.unwrap();
+    assert_eq!(ssum.sum, sum.sum);
+    assert_eq!(ssum.num, sum.num);
+}
+
+async fn divide_stream(cli: streaming_ttrpc::StreamingClient) {
+    let expected = streaming::Sum {
+        sum: 392,
+        num: 4,
+        ..Default::default()
+    };
+    let mut stream = cli.divide_stream(default_ctx(), &expected).await.unwrap();
+
+    let mut actual = streaming::Sum::new();
+
+    // NOTE: `for part in stream.recv().await.unwrap()` can't work.
+    while let Some(part) = stream.recv().await.unwrap() {
+        actual.sum += part.add;
+        actual.num += 1;
+    }
+    assert_eq!(actual.sum, expected.sum);
+    assert_eq!(actual.num, expected.num);
+}
+
+async fn echo_null(cli: streaming_ttrpc::StreamingClient) {
+    let mut stream = cli.echo_null(default_ctx()).await.unwrap();
+
+    for i in 0..100 {
+        let echo = streaming::EchoPayload {
+            seq: i as u32,
+            msg: "non-empty empty".to_string(),
+            ..Default::default()
+        };
+        stream.send(&echo).await.unwrap();
+    }
+    let res = stream.close_and_recv().await.unwrap();
+    assert_eq!(res, empty::Empty::new());
+}
+
+async fn echo_null_stream(cli: streaming_ttrpc::StreamingClient) {
+    let stream = cli.echo_null_stream(default_ctx()).await.unwrap();
+
+    let (tx, mut rx) = stream.split();
+
+    let task = tokio::spawn(async move {
+        loop {
+            let ret = rx.recv().await;
+            if matches!(ret, Err(ttrpc::Error::Eof)) {
+                break;
+            }
+        }
+    });
+
+    for i in 0..100 {
+        let echo = streaming::EchoPayload {
+            seq: i as u32,
+            msg: "non-empty empty".to_string(),
+            ..Default::default()
+        };
+        tx.send(&echo).await.unwrap();
+    }
+
+    tx.close_send().await.unwrap();
+
+    tokio::time::timeout(tokio::time::Duration::from_secs(10), task)
+        .await
+        .unwrap()
+        .unwrap();
+}

--- a/example/async-stream-server.rs
+++ b/example/async-stream-server.rs
@@ -1,0 +1,170 @@
+// Copyright 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+mod protocols;
+mod utils;
+
+use std::sync::Arc;
+
+use log::{info, LevelFilter};
+
+use protocols::r#async::{empty, streaming, streaming_ttrpc};
+use ttrpc::asynchronous::Server;
+
+use async_trait::async_trait;
+use tokio::signal::unix::{signal, SignalKind};
+use tokio::time::sleep;
+
+struct StreamingService;
+
+#[async_trait]
+impl streaming_ttrpc::Streaming for StreamingService {
+    async fn echo(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        mut e: streaming::EchoPayload,
+    ) -> ::ttrpc::Result<streaming::EchoPayload> {
+        e.seq += 1;
+        Ok(e)
+    }
+
+    async fn echo_stream(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        mut s: ::ttrpc::r#async::ServerStream<streaming::EchoPayload, streaming::EchoPayload>,
+    ) -> ::ttrpc::Result<()> {
+        while let Some(mut e) = s.recv().await? {
+            e.seq += 1;
+            s.send(&e).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn sum_stream(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        mut s: ::ttrpc::r#async::ServerStreamReceiver<streaming::Part>,
+    ) -> ::ttrpc::Result<streaming::Sum> {
+        let mut sum = streaming::Sum::new();
+        while let Some(part) = s.recv().await? {
+            sum.sum += part.add;
+            sum.num += 1;
+        }
+
+        Ok(sum)
+    }
+
+    async fn divide_stream(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        sum: streaming::Sum,
+        s: ::ttrpc::r#async::ServerStreamSender<streaming::Part>,
+    ) -> ::ttrpc::Result<()> {
+        let mut parts = vec![streaming::Part::new(); sum.num as usize];
+
+        let mut total = 0i32;
+        for i in 1..(sum.num - 2) {
+            let add = (rand::random::<u32>() % 1000) as i32 - 500;
+            parts[i as usize].add = add;
+            total += add;
+        }
+
+        parts[sum.num as usize - 2].add = sum.sum - total;
+
+        for part in parts {
+            s.send(&part).await.unwrap();
+        }
+
+        Ok(())
+    }
+
+    async fn echo_null(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        mut s: ::ttrpc::r#async::ServerStreamReceiver<streaming::EchoPayload>,
+    ) -> ::ttrpc::Result<empty::Empty> {
+        let mut seq = 0;
+        while let Some(e) = s.recv().await? {
+            assert_eq!(e.seq, seq);
+            assert_eq!(e.msg.as_str(), "non-empty empty");
+            seq += 1;
+        }
+        Ok(empty::Empty::new())
+    }
+
+    async fn echo_null_stream(
+        &self,
+        _ctx: &::ttrpc::r#async::TtrpcContext,
+        s: ::ttrpc::r#async::ServerStream<empty::Empty, streaming::EchoPayload>,
+    ) -> ::ttrpc::Result<()> {
+        let msg = "non-empty empty".to_string();
+
+        let mut tasks = Vec::new();
+
+        let (tx, mut rx) = s.split();
+        let mut seq = 0u32;
+        while let Some(e) = rx.recv().await? {
+            assert_eq!(e.seq, seq);
+            assert_eq!(e.msg, msg);
+            seq += 1;
+
+            for _i in 0..10 {
+                let tx = tx.clone();
+                tasks.push(tokio::spawn(
+                    async move { tx.send(&empty::Empty::new()).await },
+                ));
+            }
+        }
+
+        for t in tasks {
+            t.await.unwrap().map_err(|e| {
+                ::ttrpc::Error::RpcStatus(::ttrpc::get_status(
+                    ::ttrpc::Code::UNKNOWN,
+                    e.to_string(),
+                ))
+            })?;
+        }
+        Ok(())
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    simple_logging::log_to_stderr(LevelFilter::Info);
+
+    let s = Box::new(StreamingService {}) as Box<dyn streaming_ttrpc::Streaming + Send + Sync>;
+    let s = Arc::new(s);
+    let service = streaming_ttrpc::create_streaming(s);
+
+    utils::remove_if_sock_exist(utils::SOCK_ADDR).unwrap();
+
+    let mut server = Server::new()
+        .bind(utils::SOCK_ADDR)
+        .unwrap()
+        .register_service(service);
+
+    let mut hangup = signal(SignalKind::hangup()).unwrap();
+    let mut interrupt = signal(SignalKind::interrupt()).unwrap();
+    server.start().await.unwrap();
+
+    tokio::select! {
+        _ = hangup.recv() => {
+            // test stop_listen -> start
+            info!("stop listen");
+            server.stop_listen().await;
+            info!("start listen");
+            server.start().await.unwrap();
+
+            // hold some time for the new test connection.
+            sleep(std::time::Duration::from_secs(100)).await;
+        }
+        _ = interrupt.recv() => {
+            // test graceful shutdown
+            info!("graceful shutdown");
+            server.shutdown().await.unwrap();
+        }
+    };
+}

--- a/example/build.rs
+++ b/example/build.rs
@@ -9,7 +9,7 @@ use ttrpc_codegen::Codegen;
 use ttrpc_codegen::Customize;
 
 fn main() {
-    let protos = vec![
+    let mut protos = vec![
         "protocols/protos/github.com/kata-containers/agent/pkg/types/types.proto",
         "protocols/protos/agent.proto",
         "protocols/protos/health.proto",
@@ -27,6 +27,9 @@ fn main() {
         })
         .run()
         .expect("Gen sync code failed.");
+
+    // Only async support stream currently.
+    protos.push("protocols/protos/streaming.proto");
 
     Codegen::new()
         .out_dir("protocols/asynchronous")

--- a/example/protocols/asynchronous/mod.rs
+++ b/example/protocols/asynchronous/mod.rs
@@ -10,3 +10,5 @@ pub mod health;
 pub mod health_ttrpc;
 mod oci;
 pub mod types;
+pub mod streaming;
+pub mod streaming_ttrpc;

--- a/example/protocols/protos/streaming.proto
+++ b/example/protocols/protos/streaming.proto
@@ -1,0 +1,49 @@
+/*
+	Copyright The containerd Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+syntax = "proto3";
+
+package ttrpc.test.streaming;
+
+import "google/protobuf/empty.proto";
+
+// Shim service is launched for each container and is responsible for owning the IO
+// for the container and its additional processes.  The shim is also the parent of
+// each container and allows reattaching to the IO and receiving the exit status
+// for the container processes.
+
+service Streaming {
+	rpc Echo(EchoPayload) returns (EchoPayload);
+	rpc EchoStream(stream EchoPayload) returns (stream EchoPayload);
+	rpc SumStream(stream Part) returns (Sum);
+	rpc DivideStream(Sum) returns (stream Part);
+	rpc EchoNull(stream EchoPayload) returns (google.protobuf.Empty);
+	rpc EchoNullStream(stream EchoPayload) returns (stream google.protobuf.Empty);
+}
+
+message EchoPayload {
+	uint32 seq = 1;
+	string msg = 2;
+}
+
+message Part {
+	int32 add = 1;
+}
+
+message Sum {
+	int32 sum = 1;
+	int32 num = 2;
+}

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -3,23 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use nix::unistd::close;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
-use crate::common::client_connect;
-use crate::error::{Error, Result};
-use crate::proto::{Code, Codec, GenMessage, Message, Request, Response, MESSAGE_TYPE_RESPONSE};
-
-use crate::r#async::utils;
+use nix::unistd::close;
 use tokio::{
     self,
     io::split,
     sync::mpsc::{channel, Receiver, Sender},
     sync::Notify,
 };
+
+use crate::common::client_connect;
+use crate::error::{Error, Result};
+use crate::proto::{Code, Codec, GenMessage, Message, Request, Response, MESSAGE_TYPE_RESPONSE};
+use crate::r#async::utils;
 
 type RequestSender = Sender<(GenMessage, Sender<Result<Vec<u8>>>)>;
 type RequestReceiver = Receiver<(GenMessage, Sender<Result<Vec<u8>>>)>;

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -9,9 +9,9 @@ use std::collections::HashMap;
 use std::os::unix::io::RawFd;
 use std::sync::{Arc, Mutex};
 
-use crate::common::{client_connect, MESSAGE_TYPE_RESPONSE};
+use crate::common::client_connect;
 use crate::error::{Error, Result};
-use crate::proto::{Code, Request, Response};
+use crate::proto::{Code, Request, Response, MESSAGE_TYPE_RESPONSE};
 
 use crate::asynchronous::stream::{receive, to_req_buf};
 use crate::r#async::utils;
@@ -163,6 +163,7 @@ impl Client {
         Client { req_tx }
     }
 
+    /// Requsts a unary request and returns with response.
     pub async fn request(&self, req: Request) -> Result<Response> {
         let mut buf = Vec::with_capacity(req.compute_size() as usize);
         {

--- a/src/asynchronous/connection.rs
+++ b/src/asynchronous/connection.rs
@@ -1,0 +1,110 @@
+// Copyright 2022 Alibaba Cloud. All rights reserved.
+// Copyright (c) 2020 Ant Financial
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::os::unix::io::AsRawFd;
+
+use async_trait::async_trait;
+use log::{error, trace};
+use tokio::{
+    io::{split, AsyncRead, AsyncWrite, ReadHalf},
+    select, task,
+};
+
+use crate::error::Error;
+use crate::proto::GenMessage;
+
+pub trait Builder {
+    type Reader;
+    type Writer;
+
+    fn build(&mut self) -> (Self::Reader, Self::Writer);
+}
+
+#[async_trait]
+pub trait WriterDelegate {
+    async fn recv(&mut self) -> Option<GenMessage>;
+    async fn disconnect(&self, msg: &GenMessage, e: Error);
+    async fn exit(&self);
+}
+
+#[async_trait]
+pub trait ReaderDelegate {
+    async fn wait_shutdown(&self);
+    async fn disconnect(&self, e: Error, task: &mut task::JoinHandle<()>);
+    async fn exit(&self);
+    async fn handle_msg(&self, msg: GenMessage);
+}
+
+pub struct Connection<S, B: Builder> {
+    reader: ReadHalf<S>,
+    writer_task: task::JoinHandle<()>,
+    reader_delegate: B::Reader,
+}
+
+impl<S, B> Connection<S, B>
+where
+    S: AsyncRead + AsyncWrite + AsRawFd + Send + 'static,
+    B: Builder,
+    B::Reader: ReaderDelegate + Send + Sync + 'static,
+    B::Writer: WriterDelegate + Send + Sync + 'static,
+{
+    pub fn new(conn: S, mut builder: B) -> Self {
+        let (reader, mut writer) = split(conn);
+
+        let (reader_delegate, mut writer_delegate) = builder.build();
+
+        let writer_task = tokio::spawn(async move {
+            while let Some(msg) = writer_delegate.recv().await {
+                trace!("write message: {:?}", msg);
+                if let Err(e) = msg.write_to(&mut writer).await {
+                    error!("write_message got error: {:?}", e);
+                    writer_delegate.disconnect(&msg, e).await;
+                }
+            }
+            writer_delegate.exit().await;
+            trace!("Writer task exit.");
+        });
+
+        Self {
+            reader,
+            writer_task,
+            reader_delegate,
+        }
+    }
+
+    pub async fn run(self) -> std::io::Result<()> {
+        let Connection {
+            mut reader,
+            mut writer_task,
+            reader_delegate,
+        } = self;
+        loop {
+            select! {
+                res = GenMessage::read_from(&mut reader) => {
+                    match res {
+                        Ok(msg) => {
+                            trace!("Got Message {:?}", msg);
+                            reader_delegate.handle_msg(msg).await;
+                        }
+                        Err(e) => {
+                            trace!("Read msg err: {:?}", e);
+                            reader_delegate.disconnect(e, &mut writer_task).await;
+                            break;
+                        }
+                    }
+                }
+                _v = reader_delegate.wait_shutdown() => {
+                    trace!("Receive shutdown.");
+                    break;
+                }
+            }
+        }
+        reader_delegate.exit().await;
+        trace!("Reader task exit.");
+
+        Ok(())
+    }
+}

--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -12,6 +12,7 @@ mod stream;
 #[doc(hidden)]
 mod utils;
 mod unix_incoming;
+pub mod shutdown;
 
 #[doc(inline)]
 pub use crate::r#async::client::Client;

--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -15,9 +15,10 @@ mod connection;
 pub mod shutdown;
 mod unix_incoming;
 
+pub use self::stream::{Kind, StreamInner};
 #[doc(inline)]
 pub use crate::r#async::client::Client;
 #[doc(inline)]
-pub use crate::r#async::server::Server;
+pub use crate::r#async::server::{Server, Service};
 #[doc(inline)]
-pub use utils::{MethodHandler, TtrpcContext};
+pub use utils::{MethodHandler, StreamHandler, TtrpcContext};

--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -11,8 +11,9 @@ mod stream;
 #[macro_use]
 #[doc(hidden)]
 mod utils;
-mod unix_incoming;
+mod connection;
 pub mod shutdown;
+mod unix_incoming;
 
 #[doc(inline)]
 pub use crate::r#async::client::Client;

--- a/src/asynchronous/mod.rs
+++ b/src/asynchronous/mod.rs
@@ -15,7 +15,10 @@ mod connection;
 pub mod shutdown;
 mod unix_incoming;
 
-pub use self::stream::{Kind, StreamInner};
+pub use self::stream::{
+    ClientStream, ClientStreamReceiver, ClientStreamSender, Kind, ServerStream,
+    ServerStreamReceiver, ServerStreamSender, StreamInner,
+};
 #[doc(inline)]
 pub use crate::r#async::client::Client;
 #[doc(inline)]

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -13,12 +13,11 @@ use std::time::Duration;
 
 use crate::asynchronous::stream::{receive, respond, respond_with_status};
 use crate::asynchronous::unix_incoming::UnixIncoming;
-use crate::common::{self, Domain, MESSAGE_TYPE_REQUEST};
+use crate::common::{self, Domain};
 use crate::context;
 use crate::error::{get_status, Error, Result};
-use crate::proto::{Code, Status};
+use crate::proto::{Code, MessageHeader, Status, MESSAGE_TYPE_REQUEST};
 use crate::r#async::{MethodHandler, TtrpcContext};
-use crate::MessageHeader;
 use futures::stream::Stream;
 use futures::StreamExt as _;
 use std::marker::Unpin;

--- a/src/asynchronous/shutdown.rs
+++ b/src/asynchronous/shutdown.rs
@@ -1,0 +1,311 @@
+// Copyright 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+use tokio::time::{error::Elapsed, timeout, Duration};
+
+#[derive(Debug)]
+struct Shared {
+    shutdown: AtomicBool,
+    notify_shutdown: Notify,
+
+    waiters: AtomicUsize,
+    notify_exit: Notify,
+}
+
+impl Shared {
+    fn is_shutdown(&self) -> bool {
+        self.shutdown.load(Ordering::Relaxed)
+    }
+}
+
+/// Wait for the shutdown notification.
+#[derive(Debug)]
+pub struct Waiter {
+    shared: Arc<Shared>,
+}
+
+/// Used to Notify all [`Waiter`s](Waiter) shutdown.
+///
+/// No `Clone` is provided. If you want multiple instances, you can use Arc<Notifier>.
+/// Notifier will automatically call shutdown when dropping.
+#[derive(Debug)]
+pub struct Notifier {
+    shared: Arc<Shared>,
+    wait_time: Option<Duration>,
+}
+
+/// Create a new shutdown pair([`Notifier`], [`Waiter`]) without timeout.
+///
+/// The [`Notifier`]
+pub fn new() -> (Notifier, Waiter) {
+    _with_timeout(None)
+}
+
+/// Create a new shutdown pair with the specified [`Duration`].
+///
+/// The [`Duration`] is used to specify the timeout of the [`Notifier::wait_all_exit()`].
+///
+/// [`Duration`]: tokio::time::Duration
+pub fn with_timeout(wait_time: Duration) -> (Notifier, Waiter) {
+    _with_timeout(Some(wait_time))
+}
+
+fn _with_timeout(wait_time: Option<Duration>) -> (Notifier, Waiter) {
+    let shared = Arc::new(Shared {
+        shutdown: AtomicBool::new(false),
+        waiters: AtomicUsize::new(1),
+        notify_shutdown: Notify::new(),
+        notify_exit: Notify::new(),
+    });
+
+    let notifier = Notifier {
+        shared: shared.clone(),
+        wait_time,
+    };
+
+    let waiter = Waiter { shared };
+
+    (notifier, waiter)
+}
+
+impl Waiter {
+    /// Return `true` if the [`Notifier::shutdown()`] has been called.
+    ///
+    /// [`Notifier::shutdown()`]: Notifier::shutdown()
+    pub fn is_shutdown(&self) -> bool {
+        self.shared.is_shutdown()
+    }
+
+    /// Waiting for the [`Notifier::shutdown()`] to be called.
+    pub async fn wait_shutdown(&self) {
+        while !self.is_shutdown() {
+            let shutdown = self.shared.notify_shutdown.notified();
+            if self.is_shutdown() {
+                return;
+            }
+            shutdown.await;
+        }
+    }
+
+    fn from_shared(shared: Arc<Shared>) -> Self {
+        shared.waiters.fetch_add(1, Ordering::Relaxed);
+        Self { shared }
+    }
+}
+
+impl Clone for Waiter {
+    fn clone(&self) -> Self {
+        Self::from_shared(self.shared.clone())
+    }
+}
+
+impl Drop for Waiter {
+    fn drop(&mut self) {
+        if 1 == self.shared.waiters.fetch_sub(1, Ordering::Relaxed) {
+            self.shared.notify_exit.notify_waiters();
+        }
+    }
+}
+
+impl Notifier {
+    /// Return `true` if the [`Notifier::shutdown()`] has been called.
+    ///
+    /// [`Notifier::shutdown()`]: Notifier::shutdown()
+    pub fn is_shutdown(&self) -> bool {
+        self.shared.is_shutdown()
+    }
+
+    /// Notify all [`Waiter`s](Waiter) shutdown.
+    ///
+    /// It will cause all calls blocking at `Waiter::wait_shutdown().await` to return.
+    pub fn shutdown(&self) {
+        let is_shutdown = self.shared.shutdown.swap(true, Ordering::Relaxed);
+        if !is_shutdown {
+            self.shared.notify_shutdown.notify_waiters();
+        }
+    }
+
+    /// Return the num of all [`Waiter`]s.
+    pub fn waiters(&self) -> usize {
+        self.shared.waiters.load(Ordering::Relaxed)
+    }
+
+    /// Create a new [`Waiter`].
+    pub fn subscribe(&self) -> Waiter {
+        Waiter::from_shared(self.shared.clone())
+    }
+
+    /// Wait for all [`Waiter`]s to drop.
+    pub async fn wait_all_exit(&self) -> Result<(), Elapsed> {
+        //debug_assert!(self.shared.is_shutdown());
+        if self.waiters() == 0 {
+            return Ok(());
+        }
+        let wait = self.wait();
+        if self.waiters() == 0 {
+            return Ok(());
+        }
+        wait.await
+    }
+
+    async fn wait(&self) -> Result<(), Elapsed> {
+        if let Some(tm) = self.wait_time {
+            timeout(tm, self.shared.notify_exit.notified()).await
+        } else {
+            self.shared.notify_exit.notified().await;
+            Ok(())
+        }
+    }
+}
+
+impl Drop for Notifier {
+    fn drop(&mut self) {
+        self.shutdown()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[tokio::test]
+    async fn it_work() {
+        let (notifier, waiter) = new();
+
+        let task = tokio::spawn(async move {
+            waiter.wait_shutdown().await;
+        });
+
+        assert_eq!(notifier.waiters(), 1);
+        notifier.shutdown();
+        task.await.unwrap();
+        assert_eq!(notifier.waiters(), 0);
+    }
+
+    #[tokio::test]
+    async fn notifier_drop() {
+        let (notifier, waiter) = new();
+        assert_eq!(notifier.waiters(), 1);
+        assert!(!waiter.is_shutdown());
+        drop(notifier);
+        assert!(waiter.is_shutdown());
+        assert_eq!(waiter.shared.waiters.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn waiter_clone() {
+        let (notifier, waiter1) = new();
+        assert_eq!(notifier.waiters(), 1);
+
+        let waiter2 = waiter1.clone();
+        assert_eq!(notifier.waiters(), 2);
+
+        let waiter3 = notifier.subscribe();
+        assert_eq!(notifier.waiters(), 3);
+
+        drop(waiter2);
+        assert_eq!(notifier.waiters(), 2);
+
+        let task = tokio::spawn(async move {
+            waiter3.wait_shutdown().await;
+            assert!(waiter3.is_shutdown());
+        });
+
+        assert!(!waiter1.is_shutdown());
+        notifier.shutdown();
+        assert!(waiter1.is_shutdown());
+
+        task.await.unwrap();
+
+        assert_eq!(notifier.waiters(), 1);
+    }
+
+    #[tokio::test]
+    async fn concurrency_notifier_shutdown() {
+        let (notifier, waiter) = new();
+        let arc_notifier = Arc::new(notifier);
+        let notifier1 = arc_notifier.clone();
+        let notifier2 = notifier1.clone();
+
+        let task1 = tokio::spawn(async move {
+            assert_eq!(notifier1.waiters(), 1);
+
+            let waiter = notifier1.subscribe();
+            assert_eq!(notifier1.waiters(), 2);
+
+            notifier1.shutdown();
+            waiter.wait_shutdown().await;
+        });
+
+        let task2 = tokio::spawn(async move {
+            assert_eq!(notifier2.waiters(), 1);
+            notifier2.shutdown();
+        });
+        waiter.wait_shutdown().await;
+        assert!(arc_notifier.is_shutdown());
+        task1.await.unwrap();
+        task2.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn concurrency_notifier_wait() {
+        let (notifier, waiter) = new();
+        let arc_notifier = Arc::new(notifier);
+        let notifier1 = arc_notifier.clone();
+        let notifier2 = notifier1.clone();
+
+        let task1 = tokio::spawn(async move {
+            notifier1.shutdown();
+            notifier1.wait_all_exit().await.unwrap();
+        });
+
+        let task2 = tokio::spawn(async move {
+            notifier2.shutdown();
+            notifier2.wait_all_exit().await.unwrap();
+        });
+
+        waiter.wait_shutdown().await;
+        drop(waiter);
+        task1.await.unwrap();
+        task2.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn wait_all_exit() {
+        let (notifier, waiter) = new();
+        let mut tasks = Vec::with_capacity(100);
+        for i in 0..100 {
+            assert_eq!(notifier.waiters(), 1 + i);
+            let waiter1 = waiter.clone();
+            tasks.push(tokio::spawn(async move {
+                waiter1.wait_shutdown().await;
+            }));
+        }
+        drop(waiter);
+        assert_eq!(notifier.waiters(), 100);
+        notifier.shutdown();
+        notifier.wait_all_exit().await.unwrap();
+        for t in tasks {
+            t.await.unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn wait_timeout() {
+        let (notifier, waiter) = with_timeout(Duration::from_millis(100));
+        let task = tokio::spawn(async move {
+            waiter.wait_shutdown().await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+        notifier.shutdown();
+        // Elapsed
+        assert!(matches!(notifier.wait_all_exit().await, Err(_)));
+        task.await.unwrap();
+    }
+}

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::common::{MESSAGE_HEADER_LENGTH, MESSAGE_LENGTH_MAX, MESSAGE_TYPE_RESPONSE};
 use crate::error::{get_rpc_status, sock_error_msg, Error, Result};
-use crate::proto::{Code, Response, Status};
+use crate::proto::{
+    Code, Response, Status, MESSAGE_HEADER_LENGTH, MESSAGE_LENGTH_MAX, MESSAGE_TYPE_RESPONSE,
+};
 use crate::r#async::utils;
 use crate::MessageHeader;
 use protobuf::Message;

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -3,129 +3,40 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use protobuf::Message;
-use tokio::io::AsyncReadExt;
+use tokio::sync::mpsc;
 
-use crate::error::{get_rpc_status, sock_error_msg, Error, Result};
-use crate::proto::{
-    Code, Response, Status, MESSAGE_HEADER_LENGTH, MESSAGE_LENGTH_MAX, MESSAGE_TYPE_RESPONSE,
-};
-use crate::r#async::utils;
+use crate::error::{Error, Result};
+use crate::proto::{Codec, GenMessage, Response, Status};
 use crate::MessageHeader;
 
-async fn receive_count<T>(reader: &mut T, count: usize) -> Result<Vec<u8>>
-where
-    T: AsyncReadExt + std::marker::Unpin,
-{
-    let mut content = vec![0u8; count];
-    if let Err(e) = reader.read_exact(&mut content).await {
-        return Err(Error::Socket(e.to_string()));
-    }
+pub type MessageSender = mpsc::Sender<GenMessage>;
+pub type MessageReceiver = mpsc::Receiver<GenMessage>;
 
-    Ok(content)
-}
+pub type ResultSender = mpsc::Sender<Result<GenMessage>>;
+pub type ResultReceiver = mpsc::Receiver<Result<GenMessage>>;
 
-async fn receive_header<T>(reader: &mut T) -> Result<MessageHeader>
-where
-    T: AsyncReadExt + std::marker::Unpin,
-{
-    let buf = receive_count(reader, MESSAGE_HEADER_LENGTH).await?;
-    let size = buf.len();
-    if size != MESSAGE_HEADER_LENGTH {
-        return Err(sock_error_msg(
-            size,
-            format!("Message header length {} is too small", size),
-        ));
-    }
-
-    let mh = MessageHeader::from(&buf);
-
-    Ok(mh)
-}
-
-pub(crate) async fn receive<T>(reader: &mut T) -> Result<(MessageHeader, Vec<u8>)>
-where
-    T: AsyncReadExt + std::marker::Unpin,
-{
-    let mh = receive_header(reader).await?;
-    trace!("Got Message header {:?}", mh);
-
-    if mh.length > MESSAGE_LENGTH_MAX as u32 {
-        return Err(get_rpc_status(
-            Code::INVALID_ARGUMENT,
-            format!(
-                "message length {} exceed maximum message size of {}",
-                mh.length, MESSAGE_LENGTH_MAX
-            ),
-        ));
-    }
-
-    let buf = receive_count(reader, mh.length as usize).await?;
-    let size = buf.len();
-    if size != mh.length as usize {
-        return Err(sock_error_msg(
-            size,
-            format!("Message length {} is not {}", size, mh.length),
-        ));
-    }
-    trace!("Got Message body {:?}", buf);
-
-    Ok((mh, buf))
-}
-
-fn header_to_buf(mh: MessageHeader) -> Vec<u8> {
-    mh.into()
-}
-
-pub(crate) fn to_res_buf(stream_id: u32, mut body: Vec<u8>) -> Vec<u8> {
-    let header = utils::get_response_header_from_body(stream_id, &body);
-    let mut buf = header_to_buf(header);
-    buf.append(&mut body);
-
-    buf
-}
-
-fn get_response_body(res: &Response) -> Result<Vec<u8>> {
-    let mut buf = Vec::with_capacity(res.compute_size() as usize);
-    let mut s = protobuf::CodedOutputStream::vec(&mut buf);
-    res.write_to(&mut s).map_err(err_to_others_err!(e, ""))?;
-    s.flush().map_err(err_to_others_err!(e, ""))?;
-
-    Ok(buf)
-}
-
-pub(crate) async fn respond(
-    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
-    stream_id: u32,
-    body: Vec<u8>,
-) -> Result<()> {
-    let buf = to_res_buf(stream_id, body);
-
-    tx.send(buf)
-        .await
-        .map_err(err_to_others_err!(e, "Send packet to sender error "))
-}
-
-pub(crate) async fn respond_with_status(
-    tx: tokio::sync::mpsc::Sender<Vec<u8>>,
-    stream_id: u32,
-    status: Status,
-) -> Result<()> {
-    let mut res = Response::new();
-    res.set_status(status);
-    let mut body = get_response_body(&res)?;
-
-    let mh = MessageHeader {
-        length: body.len() as u32,
-        stream_id,
-        type_: MESSAGE_TYPE_RESPONSE,
-        flags: 0,
+pub(crate) async fn respond(tx: MessageSender, stream_id: u32, resp: Response) -> Result<()> {
+    let payload = resp
+        .encode()
+        .map_err(err_to_others_err!(e, "Encode Response failed."))?;
+    let msg = GenMessage {
+        header: MessageHeader::new_response(stream_id, payload.len() as u32),
+        payload,
     };
 
-    let mut buf = header_to_buf(mh);
-    buf.append(&mut body);
-
-    tx.send(buf)
+    tx.send(msg)
         .await
         .map_err(err_to_others_err!(e, "Send packet to sender error "))
+}
+
+pub(crate) async fn respond_with_status(tx: MessageSender, stream_id: u32, status: Status) {
+    let mut res = Response::new();
+    res.set_status(status);
+
+    respond(tx, stream_id, res)
+        .await
+        .map_err(|e| {
+            error!("respond with status got error {:?}", e);
+        })
+        .ok();
 }

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -3,13 +3,193 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+
 use tokio::sync::mpsc;
 
-use crate::error::Result;
-use crate::proto::GenMessage;
+use crate::error::{Error, Result};
+use crate::proto::{
+    Code, Codec, GenMessage, MessageHeader, Response, FLAG_NO_DATA, FLAG_REMOTE_CLOSED,
+    MESSAGE_TYPE_DATA, MESSAGE_TYPE_RESPONSE,
+};
 
 pub type MessageSender = mpsc::Sender<GenMessage>;
 pub type MessageReceiver = mpsc::Receiver<GenMessage>;
 
 pub type ResultSender = mpsc::Sender<Result<GenMessage>>;
 pub type ResultReceiver = mpsc::Receiver<Result<GenMessage>>;
+
+async fn _recv(rx: &mut ResultReceiver) -> Result<GenMessage> {
+    rx.recv()
+        .await
+        .unwrap_or_else(|| Err(Error::Others("Receive packet from recver error".to_string())))
+}
+
+async fn _send(tx: &MessageSender, msg: GenMessage) -> Result<()> {
+    tx.send(msg)
+        .await
+        .map_err(|e| Error::Others(format!("Send data packet to sender error {:?}", e)))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Kind {
+    Client,
+    Server,
+}
+
+#[derive(Debug)]
+pub struct StreamInner {
+    sender: StreamSender,
+    receiver: StreamReceiver,
+}
+
+impl StreamInner {
+    pub fn new(
+        stream_id: u32,
+        tx: MessageSender,
+        rx: ResultReceiver,
+        //waiter: shutdown::Waiter,
+        sendable: bool,
+        recveivable: bool,
+        kind: Kind,
+        streams: Arc<Mutex<HashMap<u32, ResultSender>>>,
+    ) -> Self {
+        Self {
+            sender: StreamSender {
+                tx,
+                stream_id,
+                sendable,
+                local_closed: Arc::new(AtomicBool::new(false)),
+                kind,
+            },
+            receiver: StreamReceiver {
+                rx,
+                stream_id,
+                recveivable,
+                remote_closed: false,
+                kind,
+                streams,
+            },
+        }
+    }
+
+    fn split(self) -> (StreamSender, StreamReceiver) {
+        (self.sender, self.receiver)
+    }
+
+    pub async fn send(&self, buf: Vec<u8>) -> Result<()> {
+        self.sender.send(buf).await
+    }
+
+    pub async fn close_send(&self) -> Result<()> {
+        self.sender.close_send().await
+    }
+
+    pub async fn recv(&mut self) -> Result<Vec<u8>> {
+        self.receiver.recv().await
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct StreamSender {
+    tx: MessageSender,
+    stream_id: u32,
+    sendable: bool,
+    local_closed: Arc<AtomicBool>,
+    kind: Kind,
+}
+
+#[derive(Debug)]
+pub struct StreamReceiver {
+    rx: ResultReceiver,
+    stream_id: u32,
+    recveivable: bool,
+    remote_closed: bool,
+    kind: Kind,
+    streams: Arc<Mutex<HashMap<u32, ResultSender>>>,
+}
+
+impl Drop for StreamReceiver {
+    fn drop(&mut self) {
+        self.streams.lock().unwrap().remove(&self.stream_id);
+    }
+}
+
+impl StreamSender {
+    pub async fn send(&self, buf: Vec<u8>) -> Result<()> {
+        debug_assert!(self.sendable);
+        if self.local_closed.load(Ordering::Relaxed) {
+            debug_assert_eq!(self.kind, Kind::Client);
+            return Err(Error::LocalClosed);
+        }
+        let header = MessageHeader::new_data(self.stream_id, buf.len() as u32);
+        let msg = GenMessage {
+            header,
+            payload: buf,
+        };
+        _send(&self.tx, msg).await?;
+
+        Ok(())
+    }
+
+    pub async fn close_send(&self) -> Result<()> {
+        debug_assert_eq!(self.kind, Kind::Client);
+        debug_assert!(self.sendable);
+        if self.local_closed.load(Ordering::Relaxed) {
+            return Err(Error::LocalClosed);
+        }
+        let mut header = MessageHeader::new_data(self.stream_id, 0);
+        header.set_flags(FLAG_REMOTE_CLOSED | FLAG_NO_DATA);
+        let msg = GenMessage {
+            header,
+            payload: Vec::new(),
+        };
+        _send(&self.tx, msg).await?;
+        self.local_closed.store(true, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+impl StreamReceiver {
+    pub async fn recv(&mut self) -> Result<Vec<u8>> {
+        if self.remote_closed {
+            return Err(Error::RemoteClosed);
+        }
+        let msg = _recv(&mut self.rx).await?;
+        let payload = match msg.header.type_ {
+            MESSAGE_TYPE_RESPONSE => {
+                debug_assert_eq!(self.kind, Kind::Client);
+                self.remote_closed = true;
+                let resp = Response::decode(&msg.payload)
+                    .map_err(err_to_others_err!(e, "Decode message failed."))?;
+                if let Some(status) = resp.status.as_ref() {
+                    if status.get_code() != Code::OK {
+                        return Err(Error::RpcStatus((*status).clone()));
+                    }
+                }
+                resp.payload
+            }
+            MESSAGE_TYPE_DATA => {
+                if !self.recveivable {
+                    self.remote_closed = true;
+                    return Err(Error::Others(
+                        "received data from non-streaming server.".to_string(),
+                    ));
+                }
+                if (msg.header.flags & FLAG_REMOTE_CLOSED) == FLAG_REMOTE_CLOSED {
+                    self.remote_closed = true;
+                    if (msg.header.flags & FLAG_NO_DATA) == FLAG_NO_DATA {
+                        return Err(Error::Eof);
+                    }
+                }
+                msg.payload
+            }
+            _ => {
+                return Err(Error::Others("not support".to_string()));
+            }
+        };
+        Ok(payload)
+    }
+}

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -76,14 +76,6 @@ fn header_to_buf(mh: MessageHeader) -> Vec<u8> {
     mh.into()
 }
 
-pub(crate) fn to_req_buf(stream_id: u32, mut body: Vec<u8>) -> Vec<u8> {
-    let header = utils::get_request_header_from_body(stream_id, &body);
-    let mut buf = header_to_buf(header);
-    buf.append(&mut body);
-
-    buf
-}
-
 pub(crate) fn to_res_buf(stream_id: u32, mut body: Vec<u8>) -> Vec<u8> {
     let header = utils::get_response_header_from_body(stream_id, &body);
     let mut buf = header_to_buf(header);

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -3,14 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use protobuf::Message;
+use tokio::io::AsyncReadExt;
+
 use crate::error::{get_rpc_status, sock_error_msg, Error, Result};
 use crate::proto::{
     Code, Response, Status, MESSAGE_HEADER_LENGTH, MESSAGE_LENGTH_MAX, MESSAGE_TYPE_RESPONSE,
 };
 use crate::r#async::utils;
 use crate::MessageHeader;
-use protobuf::Message;
-use tokio::io::AsyncReadExt;
 
 async fn receive_count<T>(reader: &mut T, count: usize) -> Result<Vec<u8>>
 where

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -5,38 +5,11 @@
 
 use tokio::sync::mpsc;
 
-use crate::error::{Error, Result};
-use crate::proto::{Codec, GenMessage, Response, Status};
-use crate::MessageHeader;
+use crate::error::Result;
+use crate::proto::GenMessage;
 
 pub type MessageSender = mpsc::Sender<GenMessage>;
 pub type MessageReceiver = mpsc::Receiver<GenMessage>;
 
 pub type ResultSender = mpsc::Sender<Result<GenMessage>>;
 pub type ResultReceiver = mpsc::Receiver<Result<GenMessage>>;
-
-pub(crate) async fn respond(tx: MessageSender, stream_id: u32, resp: Response) -> Result<()> {
-    let payload = resp
-        .encode()
-        .map_err(err_to_others_err!(e, "Encode Response failed."))?;
-    let msg = GenMessage {
-        header: MessageHeader::new_response(stream_id, payload.len() as u32),
-        payload,
-    };
-
-    tx.send(msg)
-        .await
-        .map_err(err_to_others_err!(e, "Send packet to sender error "))
-}
-
-pub(crate) async fn respond_with_status(tx: MessageSender, stream_id: u32, status: Status) {
-    let mut res = Response::new();
-    res.set_status(status);
-
-    respond(tx, stream_id, res)
-        .await
-        .map_err(|e| {
-            error!("respond with status got error {:?}", e);
-        })
-        .ok();
-}

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::error::{get_status, Result};
-use crate::proto::{
-    Code, MessageHeader, Request, Status, MESSAGE_TYPE_RESPONSE,
-};
-use async_trait::async_trait;
-use protobuf::{CodedInputStream, Message};
 use std::collections::HashMap;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::result::Result as StdResult;
+
+use async_trait::async_trait;
+use protobuf::{CodedInputStream, Message};
 use tokio::net::UnixStream;
+
+use crate::error::{get_status, Result};
+use crate::proto::{Code, MessageHeader, Request, Status, MESSAGE_TYPE_RESPONSE};
 
 /// Handle request in async mode.
 #[macro_export]

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -5,7 +5,7 @@
 
 use crate::error::{get_status, Result};
 use crate::proto::{
-    Code, MessageHeader, Request, Status, MESSAGE_TYPE_REQUEST, MESSAGE_TYPE_RESPONSE,
+    Code, MessageHeader, Request, Status, MESSAGE_TYPE_RESPONSE,
 };
 use async_trait::async_trait;
 use protobuf::{CodedInputStream, Message};
@@ -105,15 +105,6 @@ pub(crate) fn get_response_header_from_body(stream_id: u32, body: &[u8]) -> Mess
         length: body.len() as u32,
         stream_id,
         type_: MESSAGE_TYPE_RESPONSE,
-        flags: 0,
-    }
-}
-
-pub(crate) fn get_request_header_from_body(stream_id: u32, body: &[u8]) -> MessageHeader {
-    MessageHeader {
-        length: body.len() as u32,
-        stream_id,
-        type_: MESSAGE_TYPE_REQUEST,
         flags: 0,
     }
 }

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -5,14 +5,12 @@
 
 use std::collections::HashMap;
 use std::os::unix::io::{FromRawFd, RawFd};
-use std::result::Result as StdResult;
 
 use async_trait::async_trait;
-use protobuf::{CodedInputStream, Message};
 use tokio::net::UnixStream;
 
-use crate::error::{get_status, Result};
-use crate::proto::{Code, MessageHeader, Request, Response, Status};
+use crate::error::Result;
+use crate::proto::{MessageHeader, Request, Response};
 
 /// Handle request in async mode.
 #[macro_export]
@@ -104,23 +102,6 @@ pub(crate) fn new_unix_stream_from_raw_fd(fd: RawFd) -> UnixStream {
     // we must set nonblocking by ourselves in tokio 1.0
     std_stream.set_nonblocking(true).unwrap();
     UnixStream::from_std(std_stream).unwrap()
-}
-
-pub(crate) fn body_to_request(body: &[u8]) -> StdResult<Request, Status> {
-    let mut req = Request::new();
-    let merge_result;
-    {
-        let mut s = CodedInputStream::from_bytes(body);
-        merge_result = req.merge_from(&mut s);
-    }
-
-    if merge_result.is_err() {
-        return Err(get_status(Code::INVALID_ARGUMENT, "".to_string()));
-    }
-
-    trace!("Got Message request {:?}", req);
-
-    Ok(req)
 }
 
 pub(crate) fn get_path(service: &str, method: &str) -> String {

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -3,9 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::common::{MessageHeader, MESSAGE_TYPE_REQUEST, MESSAGE_TYPE_RESPONSE};
 use crate::error::{get_status, Result};
-use crate::proto::{Code, Request, Status};
+use crate::proto::{
+    Code, MessageHeader, Request, Status, MESSAGE_TYPE_REQUEST, MESSAGE_TYPE_RESPONSE,
+};
 use async_trait::async_trait;
 use protobuf::{CodedInputStream, Message};
 use std::collections::HashMap;

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -84,6 +84,16 @@ pub trait MethodHandler {
     async fn handler(&self, ctx: TtrpcContext, req: Request) -> Result<Response>;
 }
 
+/// Trait that implements handler which is a proxy to the stream (async).
+#[async_trait]
+pub trait StreamHandler {
+    async fn handler(
+        &self,
+        ctx: TtrpcContext,
+        stream: crate::r#async::StreamInner,
+    ) -> Result<Option<Response>>;
+}
+
 /// The context of ttrpc (async).
 #[derive(Debug)]
 pub struct TtrpcContext {

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,7 +6,6 @@
 //! Common functions and macros.
 
 use crate::error::{Error, Result};
-use byteorder::{BigEndian, ByteOrder};
 #[cfg(any(feature = "async", not(target_os = "linux")))]
 use nix::fcntl::FdFlag;
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
@@ -18,53 +17,6 @@ pub(crate) enum Domain {
     Unix,
     #[cfg(target_os = "linux")]
     Vsock,
-}
-
-/// Message header of ttrpc.
-#[derive(Default, Debug)]
-pub struct MessageHeader {
-    pub length: u32,
-    pub stream_id: u32,
-    pub type_: u8,
-    pub flags: u8,
-}
-
-impl<T> From<T> for MessageHeader
-where
-    T: AsRef<[u8]>,
-{
-    fn from(buf: T) -> Self {
-        let buf = buf.as_ref();
-        debug_assert!(buf.len() >= MESSAGE_HEADER_LENGTH);
-        Self {
-            length: BigEndian::read_u32(&buf[..4]),
-            stream_id: BigEndian::read_u32(&buf[4..8]),
-            type_: buf[8],
-            flags: buf[9],
-        }
-    }
-}
-
-impl From<MessageHeader> for Vec<u8> {
-    fn from(mh: MessageHeader) -> Self {
-        let mut buf = vec![0u8; MESSAGE_HEADER_LENGTH];
-        mh.into_buf(&mut buf);
-        buf
-    }
-}
-
-impl MessageHeader {
-    pub(crate) fn into_buf(self, mut buf: impl AsMut<[u8]>) {
-        let buf = buf.as_mut();
-        debug_assert!(buf.len() >= MESSAGE_HEADER_LENGTH);
-
-        let covbuf: &mut [u8] = &mut buf[..4];
-        BigEndian::write_u32(covbuf, self.length);
-        let covbuf: &mut [u8] = &mut buf[4..8];
-        BigEndian::write_u32(covbuf, self.stream_id);
-        buf[8] = self.type_;
-        buf[9] = self.flags;
-    }
 }
 
 pub(crate) fn do_listen(listener: RawFd) -> Result<()> {
@@ -238,12 +190,6 @@ macro_rules! cfg_async {
     }
 }
 
-pub const MESSAGE_HEADER_LENGTH: usize = 10;
-pub const MESSAGE_LENGTH_MAX: usize = 4 << 20;
-
-pub const MESSAGE_TYPE_REQUEST: u8 = 0x1;
-pub const MESSAGE_TYPE_RESPONSE: u8 = 0x2;
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -305,24 +251,5 @@ mod tests {
                 assert!(r.is_err());
             }
         }
-    }
-
-    #[test]
-    fn message_header() {
-        let buf = vec![
-            0x10, 0x0, 0x0, 0x0, // length
-            0x0, 0x0, 0x0, 0x03, // stream_id
-            0x2,  // type_
-            0xef, // flags
-        ];
-        let mh = MessageHeader::from(&buf);
-        assert_eq!(mh.length, 0x1000_0000);
-        assert_eq!(mh.stream_id, 0x3);
-        assert_eq!(mh.type_, MESSAGE_TYPE_RESPONSE);
-        assert_eq!(mh.flags, 0xef);
-
-        let mut buf2 = vec![0; MESSAGE_HEADER_LENGTH];
-        mh.into_buf(&mut buf2);
-        assert_eq!(&buf, &buf2);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,15 @@ pub enum Error {
     #[error("Nix error: {0}")]
     Nix(#[from] nix::Error),
 
+    #[error("ttrpc err: local stream closed")]
+    LocalClosed,
+
+    #[error("ttrpc err: remote stream closed")]
+    RemoteClosed,
+
+    #[error("eof")]
+    Eof,
+
     #[error("ttrpc err: {0}")]
     Others(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,20 +48,15 @@ extern crate log;
 pub mod error;
 #[macro_use]
 mod common;
-#[allow(soft_unstable, clippy::type_complexity, clippy::too_many_arguments)]
-mod compiled {
-    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
-}
-pub use compiled::ttrpc as proto;
 
 pub mod context;
 
+pub mod proto;
 #[doc(inline)]
-pub use crate::common::MessageHeader;
+pub use self::proto::{Code, MessageHeader, Request, Response, Status};
+
 #[doc(inline)]
 pub use crate::error::{get_status, Error, Result};
-#[doc(inline)]
-pub use proto::{Code, Request, Response, Status};
 
 cfg_sync! {
     pub mod sync;

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -21,6 +21,11 @@ pub const MESSAGE_LENGTH_MAX: usize = 4 << 20;
 
 pub const MESSAGE_TYPE_REQUEST: u8 = 0x1;
 pub const MESSAGE_TYPE_RESPONSE: u8 = 0x2;
+pub const MESSAGE_TYPE_DATA: u8 = 0x3;
+
+pub const FLAG_REMOTE_CLOSED: u8 = 0x1;
+pub const FLAG_REMOTE_OPEN: u8 = 0x2;
+pub const FLAG_NO_DATA: u8 = 0x4;
 
 /// Message header of ttrpc.
 #[derive(Default, Debug, Clone, Copy, PartialEq)]
@@ -57,6 +62,7 @@ impl From<MessageHeader> for Vec<u8> {
 
 impl MessageHeader {
     /// Creates a request MessageHeader from stream_id and len.
+    ///
     /// Use the default message type MESSAGE_TYPE_REQUEST, and default flags 0.
     pub fn new_request(stream_id: u32, len: u32) -> Self {
         Self {
@@ -68,12 +74,25 @@ impl MessageHeader {
     }
 
     /// Creates a response MessageHeader from stream_id and len.
-    /// Use the default message type MESSAGE_TYPE_RESPONSE, and default flags 0.
+    ///
+    /// Use the MESSAGE_TYPE_RESPONSE message type, and default flags 0.
     pub fn new_response(stream_id: u32, len: u32) -> Self {
         Self {
             length: len,
             stream_id,
             type_: MESSAGE_TYPE_RESPONSE,
+            flags: 0,
+        }
+    }
+
+    /// Creates a data MessageHeader from stream_id and len.
+    ///
+    /// Use the MESSAGE_TYPE_DATA message type, and default flags 0.
+    pub fn new_data(stream_id: u32, len: u32) -> Self {
+        Self {
+            length: len,
+            stream_id,
+            type_: MESSAGE_TYPE_DATA,
             flags: 0,
         }
     }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -1,0 +1,122 @@
+// Copyright 2022 Alibaba Cloud. All rights reserved.
+// Copyright (c) 2020 Ant Financial
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[allow(soft_unstable, clippy::type_complexity, clippy::too_many_arguments)]
+mod compiled {
+    include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+}
+pub use compiled::ttrpc::*;
+
+use byteorder::{BigEndian, ByteOrder};
+
+pub const MESSAGE_HEADER_LENGTH: usize = 10;
+pub const MESSAGE_LENGTH_MAX: usize = 4 << 20;
+
+pub const MESSAGE_TYPE_REQUEST: u8 = 0x1;
+pub const MESSAGE_TYPE_RESPONSE: u8 = 0x2;
+
+/// Message header of ttrpc.
+#[derive(Default, Debug)]
+pub struct MessageHeader {
+    pub length: u32,
+    pub stream_id: u32,
+    pub type_: u8,
+    pub flags: u8,
+}
+
+impl<T> From<T> for MessageHeader
+where
+    T: AsRef<[u8]>,
+{
+    fn from(buf: T) -> Self {
+        let buf = buf.as_ref();
+        debug_assert!(buf.len() >= MESSAGE_HEADER_LENGTH);
+        Self {
+            length: BigEndian::read_u32(&buf[..4]),
+            stream_id: BigEndian::read_u32(&buf[4..8]),
+            type_: buf[8],
+            flags: buf[9],
+        }
+    }
+}
+
+impl From<MessageHeader> for Vec<u8> {
+    fn from(mh: MessageHeader) -> Self {
+        let mut buf = vec![0u8; MESSAGE_HEADER_LENGTH];
+        mh.into_buf(&mut buf);
+        buf
+    }
+}
+
+impl MessageHeader {
+    /// Creates a request MessageHeader from stream_id and len.
+    /// Use the default message type MESSAGE_TYPE_REQUEST, and default flags 0.
+    pub fn new_request(stream_id: u32, len: u32) -> Self {
+        Self {
+            length: len,
+            stream_id,
+            type_: MESSAGE_TYPE_REQUEST,
+            flags: 0,
+        }
+    }
+
+    /// Creates a response MessageHeader from stream_id and len.
+    /// Use the default message type MESSAGE_TYPE_REQUEST, and default flags 0.
+    pub fn new_response(stream_id: u32, len: u32) -> Self {
+        Self {
+            length: len,
+            stream_id,
+            type_: MESSAGE_TYPE_RESPONSE,
+            flags: 0,
+        }
+    }
+
+    /// Set the flags of message using the given flags.
+    pub fn set_flags(&mut self, flags: u8) {
+        self.flags = flags;
+    }
+
+    /// Add a new flags to the message.
+    pub fn add_flags(&mut self, flags: u8) {
+        self.flags |= flags;
+    }
+
+    pub(crate) fn into_buf(self, mut buf: impl AsMut<[u8]>) {
+        let buf = buf.as_mut();
+        debug_assert!(buf.len() >= MESSAGE_HEADER_LENGTH);
+
+        let covbuf: &mut [u8] = &mut buf[..4];
+        BigEndian::write_u32(covbuf, self.length);
+        let covbuf: &mut [u8] = &mut buf[4..8];
+        BigEndian::write_u32(covbuf, self.stream_id);
+        buf[8] = self.type_;
+        buf[9] = self.flags;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn message_header() {
+        let buf = vec![
+            0x10, 0x0, 0x0, 0x0, // length
+            0x0, 0x0, 0x0, 0x03, // stream_id
+            0x2,  // type_
+            0xef, // flags
+        ];
+        let mh = MessageHeader::from(&buf);
+        assert_eq!(mh.length, 0x1000_0000);
+        assert_eq!(mh.stream_id, 0x3);
+        assert_eq!(mh.type_, MESSAGE_TYPE_RESPONSE);
+        assert_eq!(mh.flags, 0xef);
+
+        let mut buf2 = vec![0; MESSAGE_HEADER_LENGTH];
+        mh.into_buf(&mut buf2);
+        assert_eq!(&buf, &buf2);
+    }
+}

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -15,10 +15,8 @@
 use nix::sys::socket::*;
 use std::os::unix::io::RawFd;
 
-use crate::common::{MESSAGE_HEADER_LENGTH, MESSAGE_LENGTH_MAX};
 use crate::error::{get_rpc_status, sock_error_msg, Error, Result};
-use crate::proto::Code;
-use crate::MessageHeader;
+use crate::proto::{Code, MessageHeader, MESSAGE_HEADER_LENGTH, MESSAGE_LENGTH_MAX};
 
 fn retryable(e: nix::Error) -> bool {
     use ::nix::Error;

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -25,11 +25,12 @@ use std::{io, thread};
 
 #[cfg(target_os = "macos")]
 use crate::common::set_fd_close_exec;
-use crate::common::{client_connect, MESSAGE_TYPE_REQUEST, MESSAGE_TYPE_RESPONSE, SOCK_CLOEXEC};
+use crate::common::{client_connect, SOCK_CLOEXEC};
 use crate::error::{Error, Result};
-use crate::proto::{Code, Request, Response};
+use crate::proto::{
+    Code, MessageHeader, Request, Response, MESSAGE_TYPE_REQUEST, MESSAGE_TYPE_RESPONSE,
+};
 use crate::sync::channel::{read_message, write_message};
-use crate::MessageHeader;
 use std::time::Duration;
 
 type Sender = mpsc::Sender<(Vec<u8>, mpsc::SyncSender<Result<Vec<u8>>>)>;

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -26,14 +26,13 @@ use std::thread::JoinHandle;
 use std::{io, thread};
 
 use super::utils::response_to_channel;
+use crate::common;
 #[cfg(not(target_os = "linux"))]
 use crate::common::set_fd_close_exec;
-use crate::common::{self, MESSAGE_TYPE_REQUEST};
 use crate::context;
 use crate::error::{get_status, Error, Result};
-use crate::proto::{Code, Request, Response};
+use crate::proto::{Code, MessageHeader, Request, Response, MESSAGE_TYPE_REQUEST};
 use crate::sync::channel::{read_message, write_message};
-use crate::MessageHeader;
 use crate::{MethodHandler, TtrpcContext};
 
 // poll_queue will create WAIT_THREAD_COUNT_DEFAULT threads in begin.

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -3,9 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::common::{MessageHeader, MESSAGE_TYPE_RESPONSE};
 use crate::error::{Error, Result};
-use crate::proto::{Request, Response};
+use crate::proto::{MessageHeader, Request, Response, MESSAGE_TYPE_RESPONSE};
 use protobuf::Message;
 use std::collections::HashMap;
 

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -16,4 +16,4 @@ readme = "README.md"
 protobuf = { version = "2.14.0" }
 protobuf-codegen-pure = "2.14.0"
 protobuf-codegen = "2.14.0"
-ttrpc-compiler = "0.5.0"
+ttrpc-compiler = { version = "0.5.0", path = "../compiler" }


### PR DESCRIPTION
Introduce support for streaming(https://github.com/containerd/ttrpc/blob/main/PROTOCOL.md#streaming). This is already supported by Golang's TTRPC in https://github.com/containerd/ttrpc/pull/107. But currently only async is implemented. Related issues #144.

This pull request changes include:
1. Improved message encoding and decoding.
2. Added `shutdown` module to handle graceful shutdown.
3. Refactored connection handling.
4. Added streaming support, and added an example about streaming.

Usually, streaming supports 3 types:
* Server streaming
* Client streaming
* Bidirectional streaming ( or duplex streaming )

These 3 types are the same as GRPC, see https://grpc.io/docs/what-is-grpc/core-concepts/#server-streaming-rpc for details.

A general `Bidirectional streaming` process is as follows:

![image](https://user-images.githubusercontent.com/8768126/172348456-212ccc1e-aa0e-4210-a191-420f55aabd50.png)

The `Connection` is an abstraction of a connection. One connection is handled as one `Write` async-task and one `Read` async-task. 
* The `Write` task receives the message from the channel and writes it to the connection.
* The `Read` task receives the message from the connection and writes it to the channel.