### PR TITLE
ttrpc-codegen: Fix clippy warnings about expect_err

### DIFF
--- a/ttrpc-codegen/src/parser.rs
+++ b/ttrpc-codegen/src/parser.rs
@@ -2190,7 +2190,7 @@ mod test {
             dfgdg
         "#;
 
-        let err = FileDescriptor::parse(msg).err().expect("err");
+        let err = FileDescriptor::parse(msg).expect_err("err");
         assert_eq!(3, err.line);
     }
 


### PR DESCRIPTION
Got:
error: called `.err().expect()` on a `Result` value
    --> src/parser.rs:2193:46
     |
2193 |         let err = FileDescriptor::parse(msg).err().expect("err");
     |                                              ^^^^^^^^^^^^ help: try: `expect_err`
     |
     = note: `-D clippy::err-expect` implied by `-D warnings`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#err_expect

This commit fixes this problem.

