### PR TITLE
Release ttrpc-compiler v0.6.0 and ttrpc-codegen v0.4.0

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-compiler"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"

--- a/compiler/README.md
+++ b/compiler/README.md
@@ -11,5 +11,6 @@ generate rust version ttrpc code from proto files.
 | ttrpc-compiler version | ttrpc version |
 | ------------- | ------------- |
 | 0.3.x | <= 0.4.x |
-| 0.4.x | = 0.5.x  |
-| 0.5.x | >= 0.6.x |
+| 0.4.x | == 0.5.x  |
+| 0.5.x | == 0.6.x |
+| 0.6.x | >= 0.7.x |

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-codegen"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"
@@ -16,4 +16,4 @@ readme = "README.md"
 protobuf = { version = "2.14.0" }
 protobuf-codegen-pure = "2.14.0"
 protobuf-codegen = "2.14.0"
-ttrpc-compiler = { version = "0.5.0", path = "../compiler" }
+ttrpc-compiler = "0.6.0"

--- a/ttrpc-codegen/README.md
+++ b/ttrpc-codegen/README.md
@@ -44,8 +44,9 @@ ttrpc-codegen = "0.2"
 | ttrpc-codegen version | ttrpc version |
 | ------------- | ------------- |
 | 0.1.x | <= 0.4.x  |
-| 0.2.x | >= 0.5.x  |
-| 0.3.x | >= 0.6.x  |
+| 0.2.x | == 0.5.x  |
+| 0.3.x | == 0.6.x  |
+| 0.4.x | >= 0.7.x  |
 
 ## Alternative
 The alternative is to use


### PR DESCRIPTION
Because https://github.com/containerd/ttrpc-rust/pull/146 introduces incompatible changes, we should bump the major version of `ttrpc-compiler`.  and because we bump the dependency `ttrpc-compiler` in `ttrpc-codegen`, we should bump the major version of `ttrpc-codegen` too.