### PR TITLE
clippy: fix warnings in rust 1.63

### DIFF
--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -309,9 +309,11 @@ where
 }
 
 async fn _recv(rx: &mut ResultReceiver) -> Result<GenMessage> {
-    rx.recv()
-        .await
-        .unwrap_or_else(|| Err(Error::Others("Receive packet from recver error".to_string())))
+    rx.recv().await.unwrap_or_else(|| {
+        Err(Error::Others(
+            "Receive packet from recver error".to_string(),
+        ))
+    })
 }
 
 async fn _send(tx: &MessageSender, msg: GenMessage) -> Result<()> {
@@ -320,7 +322,7 @@ async fn _send(tx: &MessageSender, msg: GenMessage) -> Result<()> {
         .map_err(|e| Error::Others(format!("Send data packet to sender error {:?}", e)))
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Kind {
     Client,
     Server,

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -28,7 +28,7 @@ pub const FLAG_REMOTE_OPEN: u8 = 0x2;
 pub const FLAG_NO_DATA: u8 = 0x4;
 
 /// Message header of ttrpc.
-#[derive(Default, Debug, Clone, Copy, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MessageHeader {
     pub length: u32,
     pub stream_id: u32,
@@ -150,7 +150,7 @@ impl MessageHeader {
 }
 
 /// Generic message of ttrpc.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct GenMessage {
     pub header: MessageHeader,
     pub payload: Vec<u8>,
@@ -236,7 +236,7 @@ impl<M: protobuf::Message> Codec for M {
 }
 
 /// Message of ttrpc.
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Message<C> {
     pub header: MessageHeader,
     pub payload: C,


### PR DESCRIPTION
Fix following clippy warnings caused by new added clippy-rules in rust 1.63.
```
error: you are deriving `PartialEq` and can implement `Eq`
  --> src/proto.rs:31:39
   |
31 | #[derive(Default, Debug, Clone, Copy, PartialEq)]
   |                                       ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
   |
   = note: `-D clippy::derive-partial-eq-without-eq` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

error: you are deriving `PartialEq` and can implement `Eq`
   --> src/asynchronous/stream.rs:323:30
    |
323 | #[derive(Clone, Copy, Debug, PartialEq)]
    |                              ^^^^^^^^^ help: consider deriving `Eq` as well: `PartialEq, Eq`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq

error: could not compile `ttrpc` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: could not compile `ttrpc` due to 2 previous errors
make: *** [Makefile:29: check] Error 101
Error: Process completed with exit code 2.
```