### PR TITLE
Add support for proto3 optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/containerd/ttrpc-rust"
 description = "A Rust version of ttrpc."
 
 [dependencies]
-protobuf = { version = "2.0" }
+protobuf = { version = "2.27.1" }
 libc = { version = "0.2.59", features = [ "extra_traits" ] }
 nix = "0.23.0"
 log = "0.4"
@@ -26,7 +26,7 @@ futures = { version = "0.3", optional = true }
 tokio-vsock = { version = "0.3.1", optional = true }
 
 [build-dependencies]
-protobuf-codegen-pure = "2.14.0"
+protobuf-codegen-pure = "2.27.1"
 
 [features]
 default = ["sync"]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://github.com/containerd/ttrpc-rust/tree/master/compiler"
 readme = "README.md"
 
 [dependencies]
-protobuf = "2.0"
-protobuf-codegen = "2.14.0"
+protobuf = "2.27.1"
+protobuf-codegen = "2.27.1"
 prost = "0.8"
 prost-build = "0.8"
 prost-types = "0.8"

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -39,12 +39,19 @@
 use std::collections::HashMap;
 
 use crate::Customize;
-use protobuf::compiler_plugin;
-use protobuf::descriptor::*;
-use protobuf::descriptorx::*;
+use protobuf::{
+    compiler_plugin::{GenRequest, GenResult},
+    descriptor::*,
+    descriptorx::*,
+    plugin::{
+        CodeGeneratorRequest, CodeGeneratorResponse, CodeGeneratorResponse_Feature,
+        CodeGeneratorResponse_File,
+    },
+    Message,
+};
 use protobuf_codegen::code_writer::CodeWriter;
 use std::fs::File;
-use std::io::{self, Write};
+use std::io::{self, stdin, stdout, Write};
 use std::path::Path;
 
 use super::util::{
@@ -659,7 +666,7 @@ fn gen_file(
     file: &FileDescriptorProto,
     root_scope: &RootScope,
     customize: &Customize,
-) -> Option<compiler_plugin::GenResult> {
+) -> Option<GenResult> {
     if file.get_service().is_empty() {
         return None;
     }
@@ -685,7 +692,7 @@ fn gen_file(
         }
     }
 
-    Some(compiler_plugin::GenResult {
+    Some(GenResult {
         name: base + "_ttrpc.rs",
         content: v,
     })
@@ -695,7 +702,7 @@ pub fn gen(
     file_descriptors: &[FileDescriptorProto],
     files_to_generate: &[String],
     customize: &Customize,
-) -> Vec<compiler_plugin::GenResult> {
+) -> Vec<GenResult> {
     let files_map: HashMap<&str, &FileDescriptorProto> =
         file_descriptors.iter().map(|f| (f.get_name(), f)).collect();
 
@@ -736,7 +743,7 @@ pub fn gen_and_write(
 }
 
 pub fn protoc_gen_grpc_rust_main() {
-    compiler_plugin::plugin_main(|file_descriptors, files_to_generate| {
+    plugin_main(|file_descriptors, files_to_generate| {
         gen(
             file_descriptors,
             files_to_generate,
@@ -745,4 +752,41 @@ pub fn protoc_gen_grpc_rust_main() {
             },
         )
     });
+}
+
+fn plugin_main<F>(gen: F)
+where
+    F: Fn(&[FileDescriptorProto], &[String]) -> Vec<GenResult>,
+{
+    plugin_main_2(|r| gen(r.file_descriptors, r.files_to_generate))
+}
+
+fn plugin_main_2<F>(gen: F)
+where
+    F: Fn(&GenRequest) -> Vec<GenResult>,
+{
+    let req = CodeGeneratorRequest::parse_from_reader(&mut stdin()).unwrap();
+    let result = gen(&GenRequest {
+        file_descriptors: &req.get_proto_file(),
+        files_to_generate: &req.get_file_to_generate(),
+        parameter: req.get_parameter(),
+    });
+    let mut resp = CodeGeneratorResponse::new();
+    resp.set_supported_features(CodeGeneratorResponse_Feature::FEATURE_PROTO3_OPTIONAL as u64);
+    resp.set_file(
+        result
+            .iter()
+            .map(|file| {
+                let mut r = CodeGeneratorResponse_File::new();
+                r.set_name(file.name.to_string());
+                r.set_content(
+                    std::str::from_utf8(file.content.as_ref())
+                        .unwrap()
+                        .to_string(),
+                );
+                r
+            })
+            .collect(),
+    );
+    resp.write_to_writer(&mut stdout()).unwrap();
 }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/alipay/ttrpc-rust"
 description = "An example of ttrpc."
 
 [dev-dependencies]
-protobuf = "2.8.0"
+protobuf = "2.27.1"
 bytes = "0.4.11"
 libc = "0.2.79"
 byteorder = "1.3.2"

--- a/example/protocols/protos/health.proto
+++ b/example/protocols/protos/health.proto
@@ -17,6 +17,7 @@ option (gogoproto.benchgen_all) = true;
 
 message CheckRequest {
 	string service = 1;
+	optional string option_val = 2;
 }
 
 message HealthCheckResponse {

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 
 [dependencies]
-protobuf = { version = "2.14.0" }
-protobuf-codegen-pure = "2.14.0"
-protobuf-codegen = "2.14.0"
+protobuf = { version = "2.27.1" }
+protobuf-codegen-pure = "2.27.1"
+protobuf-codegen = "2.27.1"
 ttrpc-compiler = "0.6.0"

--- a/ttrpc-codegen/src/parser.rs
+++ b/ttrpc-codegen/src/parser.rs
@@ -737,9 +737,9 @@ impl MessageBodyParseMode {
             },
             Rule::Optional | Rule::Required => match *self {
                 MessageBodyParseMode::MessageProto2 | MessageBodyParseMode::ExtendProto2 => true,
-                MessageBodyParseMode::MessageProto3
-                | MessageBodyParseMode::ExtendProto3
-                | MessageBodyParseMode::Oneof => false,
+                // TODO: actually use them, not just ignore
+                MessageBodyParseMode::MessageProto3 | MessageBodyParseMode::ExtendProto3 => true,
+                MessageBodyParseMode::Oneof => false,
             },
         }
     }


### PR DESCRIPTION
- [compiler: Signal that ttrpc-compiler supports proto3 optionals](https://github.com/containerd/ttrpc-rust/pull/156/commits/ebe34a20ff6c9b847dd98729ffb29995042b66ca)
- [ttrpc: bump protobuf to 2.27.1](https://github.com/containerd/ttrpc-rust/pull/156/commits/ed2a9b1a206e8339fa7d33a94dc9f6e5098819c5)
- [ttrpc-codegen: set optional as an allowd label](https://github.com/containerd/ttrpc-rust/pull/156/commits/42ac6beb4be8122fa965d7b0c8c8a19cba9e6cf6)
- [example: update for optional testing](https://github.com/containerd/ttrpc-rust/pull/156/commits/2a3b86ccf2ac3562f773b97b01ed3834463058fe)