### PR TITLE
[0.5.0] ttrpc-codegen: Fix proto3's optional support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/containerd/ttrpc-rust"
 description = "A Rust version of ttrpc."
 
 [dependencies]
-protobuf = { version = "2.27.1", optional = true }
+protobuf = { version = "2.28.0", optional = true }
 bytes = { version = "0.4.11", optional = true }
 libc = { version = "0.2.59", features = [ "extra_traits" ] }
 nix = "0.23.0"
@@ -27,7 +27,7 @@ futures = { version = "0.3", optional = true }
 tokio-vsock = { version = "0.3.1", optional = true }
 
 [build-dependencies]
-protobuf-codegen-pure = "2.27.1"
+protobuf-codegen-pure = "2.28.0"
 
 [features]
 default = ["protobuf-codec", "sync"]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -12,8 +12,8 @@ homepage = "https://github.com/containerd/ttrpc-rust/tree/master/compiler"
 readme = "README.md"
 
 [dependencies]
-protobuf = "2.27.1"
-protobuf-codegen = "2.27.1"
+protobuf = "2.28.0"
+protobuf-codegen = "2.28.0"
 prost = "0.8"
 prost-build = "0.8"
 prost-types = "0.8"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/alipay/ttrpc-rust"
 description = "An example of ttrpc."
 
 [dev-dependencies]
-protobuf = "2.27.1"
+protobuf = "2.28.0"
 bytes = "0.4.11"
 libc = "0.2.79"
 byteorder = "1.3.2"

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -13,8 +13,8 @@ readme = "README.md"
 
 
 [dependencies]
-protobuf = "2.27.1"
-protobuf-codegen = "2.27.1"
+protobuf = "2.28.0"
+protobuf-codegen = "2.28.0"
 # protobuf-codegen-pure3 is a protobuf-codegen-pure version that supports proto3 optional fields
 protobuf-codegen-pure = { version = "2.27.3", package = "protobuf-codegen-pure3" }
 ttrpc-compiler = "0.4.0"

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-codegen"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -16,5 +16,5 @@ readme = "README.md"
 protobuf = "2.28.0"
 protobuf-codegen = "2.28.0"
 # protobuf-codegen-pure3 is a protobuf-codegen-pure version that supports proto3 optional fields
-protobuf-codegen-pure = { version = "2.27.3", package = "protobuf-codegen-pure3" }
+protobuf-codegen-pure = { version = "2.28.1", package = "protobuf-codegen-pure3" }
 ttrpc-compiler = "0.4.0"

--- a/ttrpc-codegen/src/parser.rs
+++ b/ttrpc-codegen/src/parser.rs
@@ -351,12 +351,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn next_char_if_in(&mut self, alphabet: &str) -> Option<char> {
-        for c in alphabet.chars() {
-            if self.next_char_if_eq(c) {
-                return Some(c);
-            }
-        }
-        None
+        alphabet.chars().find(|&c| self.next_char_if_eq(c))
     }
 
     fn next_char_expect_eq(&mut self, expect: char) -> ParserResult<()> {


### PR DESCRIPTION
Optional field was not generated right by protobuf-codegen-pure3@2.27.3.
I have fixed the problem on version 2.28.1, so we can bump the protobuf-codegen-pure3 to 2.28.1 to fix the problem.