### PR TITLE
ttrpc: fix lint errors in build

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ fn main() {
     protobuf_codegen::Codegen::new()
         .pure()
         .out_dir(out_dir)
-        .inputs(&["src/ttrpc.proto"])
+        .inputs(["src/ttrpc.proto"])
         .include("src")
         .customize(customize)
         .run()

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -97,7 +97,7 @@ impl Client {
         };
 
         let msg = result?;
-        let res = Response::decode(&msg.payload)
+        let res = Response::decode(msg.payload)
             .map_err(err_to_others_err!(e, "Unpack response error "))?;
 
         let status = res.status();

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -103,7 +103,7 @@ where
 {
     pub async fn recv(&mut self) -> Result<P> {
         let msg_buf = self.rx.recv().await?;
-        P::decode(&msg_buf).map_err(err_to_others_err!(e, "Decode message failed."))
+        P::decode(msg_buf).map_err(err_to_others_err!(e, "Decode message failed."))
     }
 }
 
@@ -184,7 +184,7 @@ where
             return Ok(None);
         }
         let msg_buf = res?;
-        Q::decode(&msg_buf)
+        Q::decode(msg_buf)
             .map_err(err_to_others_err!(e, "Decode message failed."))
             .map(Some)
     }
@@ -221,7 +221,7 @@ where
     pub async fn close_and_recv(&mut self) -> Result<P> {
         self.inner.close_send().await?;
         let msg_buf = self.inner.recv().await?;
-        P::decode(&msg_buf).map_err(err_to_others_err!(e, "Decode message failed."))
+        P::decode(msg_buf).map_err(err_to_others_err!(e, "Decode message failed."))
     }
 }
 
@@ -273,7 +273,7 @@ where
             return Ok(None);
         }
         let msg_buf = res?;
-        P::decode(&msg_buf)
+        P::decode(msg_buf)
             .map_err(err_to_others_err!(e, "Decode message failed."))
             .map(Some)
     }
@@ -302,7 +302,7 @@ where
             return Ok(None);
         }
         let msg_buf = res?;
-        Q::decode(&msg_buf)
+        Q::decode(msg_buf)
             .map_err(err_to_others_err!(e, "Decode message failed."))
             .map(Some)
     }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -398,7 +398,7 @@ mod tests {
         assert_eq!(&buf, &PROTOBUF_REQUEST);
         let dreq = Request::decode(&buf).unwrap();
         assert_eq!(creq, dreq);
-        let dreq2 = Request::decode(&PROTOBUF_REQUEST).unwrap();
+        let dreq2 = Request::decode(PROTOBUF_REQUEST).unwrap();
         assert_eq!(creq, dreq2);
     }
 
@@ -470,7 +470,7 @@ mod tests {
         buf.extend_from_slice(&[0x0, 0x0]);
         let msg = Message::<Request>::read_from(&*buf).await.unwrap();
         assert_eq!(msg.header.length, 67);
-        assert_eq!(msg.header.length, msg.payload.size() as u32);
+        assert_eq!(msg.header.length, msg.payload.size());
         assert_eq!(msg.header.stream_id, 0x123456);
         assert_eq!(msg.header.type_, MESSAGE_TYPE_REQUEST);
         assert_eq!(msg.header.flags, 0xef);

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -229,7 +229,7 @@ impl Client {
 
         let buf = result?;
         let res =
-            Response::decode(&buf).map_err(err_to_others_err!(e, "Unpack response error "))?;
+            Response::decode(buf).map_err(err_to_others_err!(e, "Unpack response error "))?;
 
         let status = res.status();
         if status.code() != Code::OK {

--- a/ttrpc-codegen/src/convert.rs
+++ b/ttrpc-codegen/src/convert.rs
@@ -495,7 +495,7 @@ impl<'a> Resolver<'a> {
             for (oneof_index, oneof) in input.oneofs.iter().enumerate() {
                 let oneof_index = oneof_index as i32;
                 for f in &oneof.fields {
-                    fields.push(self.field(f, Some(oneof_index as i32), &nested_path_in_file)?);
+                    fields.push(self.field(f, Some(oneof_index), &nested_path_in_file)?);
                 }
             }
 
@@ -908,7 +908,7 @@ impl<'a> Resolver<'a> {
                 if field_type != &model::FieldType::Bool {
                     Err(())
                 } else {
-                    Ok(protobuf::UnknownValue::Varint(if b { 1 } else { 0 }))
+                    Ok(protobuf::UnknownValue::Varint(u64::from(b)))
                 }
             }
             // TODO: check overflow
@@ -938,7 +938,7 @@ impl<'a> Resolver<'a> {
                 | model::FieldType::Int32
                 | model::FieldType::Uint64
                 | model::FieldType::Uint32 => Ok(protobuf::UnknownValue::Varint(v as u64)),
-                model::FieldType::Sint64 => Ok(protobuf::UnknownValue::sint64(v as i64)),
+                model::FieldType::Sint64 => Ok(protobuf::UnknownValue::sint64(v)),
                 model::FieldType::Sint32 => Ok(protobuf::UnknownValue::sint32(v as i32)),
                 _ => Err(()),
             },

--- a/ttrpc-codegen/src/lib.rs
+++ b/ttrpc-codegen/src/lib.rs
@@ -258,7 +258,7 @@ impl<'a> Run<'a> {
         let mut this_file_deps = HashMap::new();
         self.get_all_deps_already_parsed(&parsed, &mut this_file_deps);
 
-        let this_file_deps: Vec<_> = this_file_deps.into_iter().map(|(_, v)| v.parsed).collect();
+        let this_file_deps: Vec<_> = this_file_deps.into_values().map(|v| v.parsed).collect();
 
         let descriptor =
             convert::file_descriptor(protobuf_path.to_owned(), &parsed, &this_file_deps).map_err(
@@ -346,8 +346,8 @@ pub fn parse_and_typecheck(
 
     let file_descriptors: Vec<_> = run
         .parsed_files
-        .into_iter()
-        .map(|(_, v)| v.descriptor)
+        .into_values()
+        .map(|v| v.descriptor)
         .collect();
 
     Ok(ParsedAndTypechecked {


### PR DESCRIPTION
Fixes needless borrow error from #165 

```
error: the borrowed expression implements the required traits
  --> build.rs:17:17
   |
17 |         .inputs(&["src/ttrpc.proto"])
   |                 ^^^^^^^^^^^^^^^^^^^^ help: change this to: `["src/ttrpc.proto"]`
   |
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

error: could not compile `ttrpc` due to previous error
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:29: check] Error 101
Error: Process completed with exit code 2.
```

Signed-off-by: Austin Vazquez <macedonv@amazon.com>