### PR TITLE
Clippy Fixes for latest rust (1.67)

### DIFF
--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -80,7 +80,7 @@ impl Client {
         self.req_tx
             .send(msg)
             .await
-            .map_err(|e| Error::Others(format!("Send packet to sender error {:?}", e)))?;
+            .map_err(|e| Error::Others(format!("Send packet to sender error {e:?}")))?;
 
         let result = if timeout_nano == 0 {
             rx.recv()
@@ -92,7 +92,7 @@ impl Client {
                 rx.recv(),
             )
             .await
-            .map_err(|e| Error::Others(format!("Receive packet timeout {:?}", e)))?
+            .map_err(|e| Error::Others(format!("Receive packet timeout {e:?}")))?
             .ok_or_else(|| Error::Others("Receive packet from receiver error".to_string()))?
         };
 
@@ -133,7 +133,7 @@ impl Client {
         self.req_tx
             .send(msg)
             .await
-            .map_err(|e| Error::Others(format!("Send packet to sender error {:?}", e)))?;
+            .map_err(|e| Error::Others(format!("Send packet to sender error {e:?}")))?;
 
         Ok(StreamInner::new(
             stream_id,
@@ -210,7 +210,7 @@ impl WriterDelegate for ClientWriter {
 
         // TODO: if None
         if let Some(resp_tx) = resp_tx {
-            let e = Error::Socket(format!("{:?}", e));
+            let e = Error::Socket(format!("{e:?}"));
             resp_tx
                 .send(Err(e))
                 .await
@@ -294,8 +294,7 @@ impl ReaderDelegate for ClientReader {
                     };
                     resp_tx
                         .send(Err(Error::Others(format!(
-                            "Recver got malformed packet {:?}",
-                            msg
+                            "Recver got malformed packet {msg:?}"
                         ))))
                         .await
                         .unwrap_or_else(|_e| error!("The request has returned"));

--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -454,8 +454,7 @@ impl HandlerContext {
                         get_status(
                             Code::INVALID_ARGUMENT,
                             format!(
-                                "Stream id {}: data close message connot include data",
-                                stream_id
+                                "Stream id {stream_id}: data close message connot include data"
                             ),
                         ),
                     )
@@ -470,7 +469,7 @@ impl HandlerContext {
                             stream_id,
                             get_status(
                                 Code::INVALID_ARGUMENT,
-                                format!("Stream id {}: handling data error: {}", stream_id, e),
+                                format!("Stream id {stream_id}: handling data error: {e}"),
                             ),
                         )
                         .await;
@@ -616,8 +615,7 @@ impl HandlerContext {
         task.await
             .unwrap_or_else(|e| {
                 Err(Error::Others(format!(
-                    "stream {} task got error {:?}",
-                    path, e
+                    "stream {path} task got error {e:?}"
                 )))
             })
             .map_err(|e| get_status(Code::UNKNOWN, e))

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -319,7 +319,7 @@ async fn _recv(rx: &mut ResultReceiver) -> Result<GenMessage> {
 async fn _send(tx: &MessageSender, msg: GenMessage) -> Result<()> {
     tx.send(msg)
         .await
-        .map_err(|e| Error::Others(format!("Send data packet to sender error {:?}", e)))
+        .map_err(|e| Error::Others(format!("Send data packet to sender error {e:?}")))
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/asynchronous/utils.rs
+++ b/src/asynchronous/utils.rs
@@ -269,5 +269,5 @@ pub(crate) fn new_unix_stream_from_raw_fd(fd: RawFd) -> UnixStream {
 }
 
 pub(crate) fn get_path(service: &str, method: &str) -> String {
-    format!("/{}/{}", service, method)
+    format!("/{service}/{method}")
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -25,8 +25,7 @@ pub(crate) enum Domain {
 pub(crate) fn do_listen(listener: RawFd) -> Result<()> {
     if let Err(e) = fcntl(listener, FcntlArg::F_SETFL(OFlag::O_NONBLOCK)) {
         return Err(Error::Others(format!(
-            "failed to set listener fd: {} as non block: {}",
-            listener, e
+            "failed to set listener fd: {listener} as non block: {e}"
         )));
     }
 
@@ -43,7 +42,7 @@ fn parse_sockaddr(addr: &str) -> Result<(Domain, &str)> {
         return Ok((Domain::Vsock, addr));
     }
 
-    Err(Error::Others(format!("Scheme {:?} is not supported", addr)))
+    Err(Error::Others(format!("Scheme {addr:?} is not supported")))
 }
 
 #[cfg(not(any(target_os = "linux", target_os = "android")))]
@@ -67,8 +66,7 @@ fn parse_sockaddr(addr: &str) -> Result<(Domain, &str)> {
 pub(crate) fn set_fd_close_exec(fd: RawFd) -> Result<RawFd> {
     if let Err(e) = fcntl(fd, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC)) {
         return Err(Error::Others(format!(
-            "failed to set fd: {} as close-on-exec: {}",
-            fd, e
+            "failed to set fd: {fd} as close-on-exec: {e}"
         )));
     }
     Ok(fd)
@@ -125,8 +123,7 @@ fn make_socket(addr: (&str, u32)) -> Result<(RawFd, Domain, SockAddr)> {
             let sockaddr_port_v: Vec<&str> = sockaddrv.split(':').collect();
             if sockaddr_port_v.len() != 2 {
                 return Err(Error::Others(format!(
-                    "sockaddr {} is not right for vsock",
-                    sockaddr
+                    "sockaddr {sockaddr} is not right for vsock"
                 )));
             }
             let port: u32 = sockaddr_port_v[1]

--- a/src/common.rs
+++ b/src/common.rs
@@ -56,7 +56,7 @@ fn parse_sockaddr(addr: &str) -> Result<(Domain, &str)> {
         return Ok((Domain::Unix, addr));
     }
 
-    Err(Error::Others(format!("Scheme {:?} is not supported", addr)))
+    Err(Error::Others(format!("Scheme {addr:?} is not supported")))
 }
 
 #[cfg(any(

--- a/src/sync/channel.rs
+++ b/src/sync/channel.rs
@@ -89,7 +89,7 @@ fn read_message_header(fd: RawFd) -> Result<MessageHeader> {
     if size != MESSAGE_HEADER_LENGTH {
         return Err(sock_error_msg(
             size,
-            format!("Message header length {} is too small", size),
+            format!("Message header length {size} is too small"),
         ));
     }
 
@@ -132,7 +132,7 @@ fn write_message_header(fd: RawFd, mh: MessageHeader) -> Result<()> {
     if size != MESSAGE_HEADER_LENGTH {
         return Err(sock_error_msg(
             size,
-            format!("Send Message header length size {} is not right", size),
+            format!("Send Message header length size {size} is not right"),
         ));
     }
 
@@ -146,7 +146,7 @@ pub fn write_message(fd: RawFd, mh: MessageHeader, buf: Vec<u8>) -> Result<()> {
     if size != buf.len() {
         return Err(sock_error_msg(
             size,
-            format!("Send Message length size {} is not right", size),
+            format!("Send Message length size {size} is not right"),
         ));
     }
 

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -152,7 +152,7 @@ impl Client {
                             let mut map = recver_map_orig.lock().unwrap();
                             for (_, recver_tx) in map.iter_mut() {
                                 recver_tx
-                                    .send(Err(Error::Socket(format!("socket error {}", y))))
+                                    .send(Err(Error::Socket(format!("socket error {y}"))))
                                     .unwrap_or_else(|e| {
                                         error!("The request has returned error {:?}", e)
                                     });
@@ -177,8 +177,7 @@ impl Client {
                 if mh.type_ != MESSAGE_TYPE_RESPONSE {
                     recver_tx
                         .send(Err(Error::Others(format!(
-                            "Recver got malformed packet {:?} {:?}",
-                            mh, buf
+                            "Recver got malformed packet {mh:?} {buf:?}"
                         ))))
                         .unwrap_or_else(|_e| error!("The request has returned"));
                     continue;

--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -190,7 +190,7 @@ fn start_method_handler_thread(
             let method = if let Some(x) = methods.get(&path) {
                 x
             } else {
-                let status = get_status(Code::INVALID_ARGUMENT, format!("{} does not exist", path));
+                let status = get_status(Code::INVALID_ARGUMENT, format!("{path} does not exist"));
                 let mut res = Response::new();
                 res.set_status(status);
                 if let Err(x) = response_to_channel(mh.stream_id, res, res_tx.clone()) {

--- a/ttrpc-codegen/src/convert.rs
+++ b/ttrpc-codegen/src/convert.rs
@@ -41,9 +41,9 @@ trait ProtobufOptions {
 impl<'a> ProtobufOptions for &'a [model::ProtobufOption] {
     fn by_name(&self, name: &str) -> Option<&model::ProtobufConstant> {
         let option_name = name;
-        for &model::ProtobufOption {
-            ref name,
-            ref value,
+        for model::ProtobufOption {
+            name,
+            value,
         } in *self
         {
             if name == option_name {
@@ -224,7 +224,7 @@ impl AbsolutePath {
         } else {
             assert!(!path.starts_with('.'));
             assert!(!path.ends_with('.'));
-            AbsolutePath::new(format!(".{}", path))
+            AbsolutePath::new(format!(".{path}"))
         }
     }
 
@@ -396,7 +396,7 @@ struct Resolver<'a> {
 
 impl<'a> Resolver<'a> {
     fn map_entry_name_for_field_name(field_name: &str) -> String {
-        format!("{}_MapEntry", field_name)
+        format!("{field_name}_MapEntry")
     }
 
     fn map_entry_field(
@@ -964,7 +964,7 @@ impl<'a> Resolver<'a> {
         v.map_err(|()| {
             ConvertError::UnsupportedExtensionType(
                 option_name.to_owned(),
-                format!("{:?}", field_type),
+                format!("{field_type:?}"),
             )
         })
     }

--- a/ttrpc-codegen/src/convert.rs
+++ b/ttrpc-codegen/src/convert.rs
@@ -41,11 +41,7 @@ trait ProtobufOptions {
 impl<'a> ProtobufOptions for &'a [model::ProtobufOption] {
     fn by_name(&self, name: &str) -> Option<&model::ProtobufConstant> {
         let option_name = name;
-        for model::ProtobufOption {
-            name,
-            value,
-        } in *self
-        {
+        for model::ProtobufOption { name, value } in *self {
             if name == option_name {
                 return Some(value);
             }

--- a/ttrpc-codegen/src/parser.rs
+++ b/ttrpc-codegen/src/parser.rs
@@ -912,7 +912,7 @@ impl<'a> Parser<'a> {
 
     fn next_ident_if_in(&mut self, idents: &[&str]) -> ParserResult<Option<String>> {
         let v = match self.lookahead()? {
-            Some(&Token::Ident(ref next)) => {
+            Some(Token::Ident(next)) => {
                 if idents.iter().any(|i| i == next) {
                     next.clone()
                 } else {


### PR DESCRIPTION
Fixes linter by running `cargo clippy --fix --all-features` after updating to latest rust tool chain with `rustup update stable` which is run in CI.

Fixes building from main branch:

```bash
make 
cargo build --verbose --all-targets
 Compiling ttrpc v0.7.1 (/home/jstur/projects/ttrpc-rust)
error: variables can be used directly in the `format!` string
  --> src/common.rs:27:34
   |
27 |           return Err(Error::Others(format!(
   |  __________________________________^
28 | |             "failed to set listener fd: {} as non block: {}",
29 | |             listener, e
30 | |         )));
   | |_________^
   |
....
```