### PR TITLE
Windows Support for Sync implementation

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,21 @@ nix = "0.23.0"
 log = "0.4"
 byteorder = "1.3.2"
 thiserror = "1.0"
-
 async-trait = { version = "0.1.31", optional = true }
 tokio = { version = "1", features = ["rt", "sync", "io-util", "macros", "time"], optional = true }
 futures = { version = "0.3", optional = true }
+
+[target.'cfg(windows)'.dependencies] 
+windows-sys = {version = "0.45", features = [ "Win32_Foundation", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_Security", "Win32_System_Threading"]}
 
 [target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 tokio-vsock = { version = "0.3.1", optional = true }
 
 [build-dependencies]
 protobuf-codegen = "3.1.0"
+
+[dev-dependencies]
+assert_cmd = "2.0.7"
 
 [features]
 default = ["sync"]

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,13 @@ build: debug
 
 .PHONY: test
 test:
+ifeq ($OS,Windows_NT)
+	# async isn't enabled for windows, don't test that feature
+	cargo test --verbose
+else
 	cargo test --all-features --verbose
-
+endif
+	
 .PHONY: check
 check:
 	cargo fmt --all -- --check

--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -5,11 +5,18 @@
 
 mod protocols;
 mod utils;
-
+#[cfg(unix)]
 use protocols::r#async::{agent, agent_ttrpc, health, health_ttrpc};
 use ttrpc::context::{self, Context};
+#[cfg(unix)]
 use ttrpc::r#async::Client;
 
+#[cfg(windows)]
+fn main() {
+    println!("This example only works on Unix-like OSes");
+}
+
+#[cfg(unix)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = Client::connect(utils::SOCK_ADDR).unwrap();

--- a/example/async-server.rs
+++ b/example/async-server.rs
@@ -13,17 +13,22 @@ use std::sync::Arc;
 
 use log::LevelFilter;
 
+#[cfg(unix)]
 use protocols::r#async::{agent, agent_ttrpc, health, health_ttrpc, types};
+#[cfg(unix)]
 use ttrpc::asynchronous::Server;
 use ttrpc::error::{Error, Result};
 use ttrpc::proto::{Code, Status};
 
+#[cfg(unix)]
 use async_trait::async_trait;
+#[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::sleep;
 
 struct HealthService;
 
+#[cfg(unix)]
 #[async_trait]
 impl health_ttrpc::Health for HealthService {
     async fn check(
@@ -58,7 +63,7 @@ impl health_ttrpc::Health for HealthService {
 }
 
 struct AgentService;
-
+#[cfg(unix)]
 #[async_trait]
 impl agent_ttrpc::AgentService for AgentService {
     async fn list_interfaces(
@@ -82,6 +87,12 @@ impl agent_ttrpc::AgentService for AgentService {
     }
 }
 
+#[cfg(windows)]
+fn main() {
+    println!("This example only works on Unix-like OSes");
+}
+
+#[cfg(unix)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     simple_logging::log_to_stderr(LevelFilter::Trace);

--- a/example/async-stream-client.rs
+++ b/example/async-stream-client.rs
@@ -5,11 +5,18 @@
 
 mod protocols;
 mod utils;
-
+#[cfg(unix)]
 use protocols::r#async::{empty, streaming, streaming_ttrpc};
 use ttrpc::context::{self, Context};
+#[cfg(unix)]
 use ttrpc::r#async::Client;
 
+#[cfg(windows)]
+fn main() {
+    println!("This example only works on Unix-like OSes");
+}
+
+#[cfg(unix)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     simple_logging::log_to_stderr(log::LevelFilter::Info);
@@ -48,6 +55,7 @@ fn default_ctx() -> Context {
     ctx
 }
 
+#[cfg(unix)]
 async fn echo_request(cli: streaming_ttrpc::StreamingClient) {
     let echo1 = streaming::EchoPayload {
         seq: 1,
@@ -59,6 +67,7 @@ async fn echo_request(cli: streaming_ttrpc::StreamingClient) {
     assert_eq!(resp.seq, echo1.seq + 1);
 }
 
+#[cfg(unix)]
 async fn echo_stream(cli: streaming_ttrpc::StreamingClient) {
     let mut stream = cli.echo_stream(default_ctx()).await.unwrap();
 
@@ -81,6 +90,7 @@ async fn echo_stream(cli: streaming_ttrpc::StreamingClient) {
     assert!(matches!(ret, Err(ttrpc::Error::Eof)));
 }
 
+#[cfg(unix)]
 async fn sum_stream(cli: streaming_ttrpc::StreamingClient) {
     let mut stream = cli.sum_stream(default_ctx()).await.unwrap();
 
@@ -108,6 +118,7 @@ async fn sum_stream(cli: streaming_ttrpc::StreamingClient) {
     assert_eq!(ssum.num, sum.num);
 }
 
+#[cfg(unix)]
 async fn divide_stream(cli: streaming_ttrpc::StreamingClient) {
     let expected = streaming::Sum {
         sum: 392,
@@ -127,6 +138,7 @@ async fn divide_stream(cli: streaming_ttrpc::StreamingClient) {
     assert_eq!(actual.num, expected.num);
 }
 
+#[cfg(unix)]
 async fn echo_null(cli: streaming_ttrpc::StreamingClient) {
     let mut stream = cli.echo_null(default_ctx()).await.unwrap();
 
@@ -142,6 +154,7 @@ async fn echo_null(cli: streaming_ttrpc::StreamingClient) {
     assert_eq!(res, empty::Empty::new());
 }
 
+#[cfg(unix)]
 async fn echo_null_stream(cli: streaming_ttrpc::StreamingClient) {
     let stream = cli.echo_null_stream(default_ctx()).await.unwrap();
 

--- a/example/async-stream-server.rs
+++ b/example/async-stream-server.rs
@@ -10,15 +10,20 @@ use std::sync::Arc;
 
 use log::{info, LevelFilter};
 
+#[cfg(unix)]
 use protocols::r#async::{empty, streaming, streaming_ttrpc};
+#[cfg(unix)]
 use ttrpc::asynchronous::Server;
 
+#[cfg(unix)]
 use async_trait::async_trait;
+#[cfg(unix)]
 use tokio::signal::unix::{signal, SignalKind};
 use tokio::time::sleep;
 
 struct StreamingService;
 
+#[cfg(unix)]
 #[async_trait]
 impl streaming_ttrpc::Streaming for StreamingService {
     async fn echo(
@@ -131,6 +136,12 @@ impl streaming_ttrpc::Streaming for StreamingService {
     }
 }
 
+#[cfg(windows)]
+fn main() {
+    println!("This example only works on Unix-like OSes");
+}
+
+#[cfg(unix)]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     simple_logging::log_to_stderr(LevelFilter::Info);

--- a/example/build.rs
+++ b/example/build.rs
@@ -45,7 +45,7 @@ fn main() {
             async_all: true,
             ..Default::default()
         })
-        .rust_protobuf_customize(protobuf_customized.clone())
+        .rust_protobuf_customize(protobuf_customized)
         .run()
         .expect("Gen async code failed.");
 
@@ -75,7 +75,7 @@ fn replace_text_in_file(file_name: &str, from: &str, to: &str) -> Result<(), std
 
     let new_contents = contents.replace(from, to);
 
-    let mut dst = File::create(&file_name)?;
+    let mut dst = File::create(file_name)?;
     dst.write(new_contents.as_bytes())?;
 
     Ok(())

--- a/example/protocols/mod.rs
+++ b/example/protocols/mod.rs
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-
+#[cfg(unix)]
 pub mod asynchronous;
-pub mod sync;
+#[cfg(unix)]
 pub use asynchronous as r#async;
+pub mod sync;

--- a/example/utils.rs
+++ b/example/utils.rs
@@ -1,18 +1,28 @@
 #![allow(dead_code)]
-use std::fs;
 use std::io::Result;
-use std::path::Path;
 
-pub const SOCK_ADDR: &str = "unix:///tmp/ttrpc-test";
+#[cfg(unix)]
+pub const SOCK_ADDR: &str = r"unix:///tmp/ttrpc-test";
 
+#[cfg(windows)]
+pub const SOCK_ADDR: &str = r"\\.\pipe\ttrpc-test";
+
+#[cfg(unix)]
 pub fn remove_if_sock_exist(sock_addr: &str) -> Result<()> {
     let path = sock_addr
         .strip_prefix("unix://")
         .expect("socket address is not expected");
 
-    if Path::new(path).exists() {
-        fs::remove_file(&path)?;
+    if std::path::Path::new(path).exists() {
+        std::fs::remove_file(path)?;
     }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn remove_if_sock_exist(_sock_addr: &str) -> Result<()> {
+    //todo force close file handle?
 
     Ok(())
 }

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -294,7 +294,7 @@ impl ReaderDelegate for ClientReader {
                     };
                     resp_tx
                         .send(Err(Error::Others(format!(
-                            "Recver got malformed packet {msg:?}"
+                            "Receiver got malformed packet {msg:?}"
                         ))))
                         .await
                         .unwrap_or_else(|_e| error!("The request has returned"));

--- a/src/asynchronous/stream.rs
+++ b/src/asynchronous/stream.rs
@@ -311,7 +311,7 @@ where
 async fn _recv(rx: &mut ResultReceiver) -> Result<GenMessage> {
     rx.recv().await.unwrap_or_else(|| {
         Err(Error::Others(
-            "Receive packet from recver error".to_string(),
+            "Receive packet from Receiver error".to_string(),
         ))
     })
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,9 +1,10 @@
+#![cfg(not(windows))]
 // Copyright (c) 2020 Ant Financial
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! Common functions and macros.
+//! Common functions.
 
 use crate::error::{Error, Result};
 #[cfg(any(
@@ -171,26 +172,6 @@ pub(crate) unsafe fn client_connect(sockaddr: &str) -> Result<RawFd> {
     connect(fd, &sockaddr)?;
 
     Ok(fd)
-}
-
-macro_rules! cfg_sync {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "sync")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
-            $item
-        )*
-    }
-}
-
-macro_rules! cfg_async {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "async")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-            $item
-        )*
-    }
 }
 
 #[cfg(test)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,8 +27,13 @@ pub enum Error {
     #[error("rpc status: {0:?}")]
     RpcStatus(Status),
 
+    #[cfg(unix)]
     #[error("Nix error: {0}")]
     Nix(#[from] nix::Error),
+
+    #[cfg(windows)]
+    #[error("Windows error: {0}")]
+    Windows(i32),
 
     #[error("ttrpc err: local stream closed")]
     LocalClosed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,9 @@ pub mod error;
 #[macro_use]
 mod common;
 
+#[macro_use]
+mod macros;
+
 pub mod context;
 
 pub mod proto;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 Ant Financial
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! macro functions.
+
+macro_rules! cfg_sync {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "sync")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_async {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "async", target_family="unix"))]
+            #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+            $item
+        )*
+    }
+}

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -14,18 +14,15 @@
 
 //! Sync client of ttrpc.
 
-use nix::sys::socket::*;
-use nix::unistd::close;
+
 use std::collections::HashMap;
 use std::os::unix::io::RawFd;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
-use std::{io, thread};
+use std::{thread};
 
-#[cfg(target_os = "macos")]
-use crate::common::set_fd_close_exec;
-use crate::common::{client_connect, SOCK_CLOEXEC};
 use crate::error::{Error, Result};
+use crate::sync::sys::{ClientConnection};
 use crate::proto::{Code, Codec, MessageHeader, Request, Response, MESSAGE_TYPE_RESPONSE};
 use crate::sync::channel::{read_message, write_message};
 use std::time::Duration;
@@ -36,38 +33,36 @@ type Receiver = mpsc::Receiver<(Vec<u8>, mpsc::SyncSender<Result<Vec<u8>>>)>;
 /// A ttrpc Client (sync).
 #[derive(Clone)]
 pub struct Client {
-    _fd: RawFd,
+    _fd: Arc<ClientConnection>,
     sender_tx: Sender,
-    _client_close: Arc<ClientClose>,
 }
 
 impl Client {
     pub fn connect(sockaddr: &str) -> Result<Client> {
-        let fd = unsafe { client_connect(sockaddr)? };
-        Ok(Self::new(fd))
+        let conn = ClientConnection::client_connect(sockaddr)?;
+        
+        Ok(Self::new_client(conn))
     }
 
     /// Initialize a new [`Client`] from raw file descriptor.
     pub fn new(fd: RawFd) -> Client {
+        let conn = ClientConnection::new(fd);
+
+        Self::new_client(conn)
+    }
+
+    fn new_client(pipe_client: ClientConnection) -> Client {
+        let client = Arc::new(pipe_client);
+        
+
         let (sender_tx, rx): (Sender, Receiver) = mpsc::channel();
 
-        let (recver_fd, close_fd) =
-            socketpair(AddressFamily::Unix, SockType::Stream, None, SOCK_CLOEXEC).unwrap();
-
-        // MacOS doesn't support descriptor creation with SOCK_CLOEXEC automically,
-        // so there is a chance of leak if fork + exec happens in between of these calls.
-        #[cfg(target_os = "macos")]
-        {
-            set_fd_close_exec(recver_fd).unwrap();
-            set_fd_close_exec(close_fd).unwrap();
-        }
-
-        let client_close = Arc::new(ClientClose { fd, close_fd });
-
+        
         let recver_map_orig = Arc::new(Mutex::new(HashMap::new()));
 
         //Sender
         let recver_map = recver_map_orig.clone();
+        let sender_client = client.clone();
         thread::spawn(move || {
             let mut stream_id: u32 = 1;
             for (buf, recver_tx) in rx.iter() {
@@ -80,7 +75,8 @@ impl Client {
                 }
                 let mut mh = MessageHeader::new_request(0, buf.len() as u32);
                 mh.set_stream_id(current_stream_id);
-                if let Err(e) = write_message(fd, mh, buf) {
+                let c = sender_client.get_pipe_connection();
+                if let Err(e) = write_message(&c, mh, buf) {
                     //Remove current_stream_id and recver_tx to recver_map
                     {
                         let mut map = recver_map.lock().unwrap();
@@ -95,53 +91,28 @@ impl Client {
         });
 
         //Recver
+        let reciever_client = client.clone();
         thread::spawn(move || {
-            let mut pollers = vec![
-                libc::pollfd {
-                    fd: recver_fd,
-                    events: libc::POLLIN,
-                    revents: 0,
-                },
-                libc::pollfd {
-                    fd,
-                    events: libc::POLLIN,
-                    revents: 0,
-                },
-            ];
+          
 
             loop {
-                let returned = unsafe {
-                    let pollers: &mut [libc::pollfd] = &mut pollers;
-                    libc::poll(
-                        pollers as *mut _ as *mut libc::pollfd,
-                        pollers.len() as _,
-                        -1,
-                    )
-                };
-
-                if returned == -1 {
-                    let err = io::Error::last_os_error();
-                    if err.raw_os_error() == Some(libc::EINTR) {
+                
+                match reciever_client.ready() {
+                    Ok(None) => {
                         continue;
                     }
-
-                    error!("fatal error in process reaper:{}", err);
-                    break;
-                } else if returned < 1 {
-                    continue;
+                    Ok(_) => {}
+                    Err(e) => {
+                        error!("pipeConnection ready error {:?}", e);
+                        break;
+                    }
                 }
-
-                if pollers[0].revents != 0 {
-                    break;
-                }
-
-                if pollers[pollers.len() - 1].revents == 0 {
-                    continue;
-                }
-
                 let mh;
                 let buf;
-                match read_message(fd) {
+
+                let pipe_connection = reciever_client.get_pipe_connection();
+
+                match read_message(&pipe_connection) {
                     Ok((x, y)) => {
                         mh = x;
                         buf = y;
@@ -190,10 +161,9 @@ impl Client {
                 map.remove(&mh.stream_id);
             }
 
-            let _ = close(recver_fd).map_err(|e| {
+            let _ = reciever_client.close_receiver().map_err(|e| {
                 warn!(
-                    "failed to close recver_fd: {} with error: {:?}",
-                    recver_fd, e
+                    "failed to close with error: {:?}", e
                 )
             });
 
@@ -201,9 +171,8 @@ impl Client {
         });
 
         Client {
-            _fd: fd,
+            _fd: client,
             sender_tx,
-            _client_close: client_close,
         }
     }
     pub fn request(&self, req: Request) -> Result<Response> {
@@ -239,15 +208,9 @@ impl Client {
     }
 }
 
-struct ClientClose {
-    fd: RawFd,
-    close_fd: RawFd,
-}
-
-impl Drop for ClientClose {
+impl Drop for ClientConnection {
     fn drop(&mut self) {
-        close(self.close_fd).unwrap();
-        close(self.fd).unwrap();
-        trace!("All client is droped");
+        self.close().unwrap();
+        trace!("All client is dropped");
     }
 }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -8,6 +8,7 @@
 mod channel;
 mod client;
 mod server;
+mod sys;
 
 #[macro_use]
 mod utils;

--- a/src/sync/sys/mod.rs
+++ b/src/sync/sys/mod.rs
@@ -3,3 +3,7 @@ mod unix;
 #[cfg(unix)]
 pub use crate::sync::sys::unix::{PipeConnection, PipeListener, ClientConnection};
 
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+pub use crate::sync::sys::windows::{PipeConnection, PipeListener, ClientConnection};

--- a/src/sync/sys/mod.rs
+++ b/src/sync/sys/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+pub use crate::sync::sys::unix::{PipeConnection, PipeListener, ClientConnection};
+

--- a/src/sync/sys/unix/mod.rs
+++ b/src/sync/sys/unix/mod.rs
@@ -1,0 +1,2 @@
+mod net;
+pub use net::{PipeConnection, PipeListener, ClientConnection};

--- a/src/sync/sys/unix/net.rs
+++ b/src/sync/sys/unix/net.rs
@@ -305,8 +305,8 @@ impl ClientConnection {
         Ok(Some(()))
     }
 
-    pub fn get_pipe_connection(&self) -> PipeConnection {
-        PipeConnection::new(self.fd)
+    pub fn get_pipe_connection(&self) -> Result<PipeConnection> {
+        Ok(PipeConnection::new(self.fd))
     }
 
     pub fn close_receiver(&self) -> Result<()> {

--- a/src/sync/sys/unix/net.rs
+++ b/src/sync/sys/unix/net.rs
@@ -1,0 +1,334 @@
+/*
+	Copyright The containerd Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+use crate::error::Result;
+use nix::sys::socket::*;
+use std::io::{self};
+use std::os::unix::io::RawFd;
+use std::os::unix::prelude::AsRawFd;
+use nix::Error;
+
+use nix::unistd::*;
+use std::sync::{Arc};
+use std::sync::atomic::{AtomicBool, Ordering};
+use crate::common::{self, client_connect, SOCK_CLOEXEC};
+#[cfg(target_os = "macos")] 
+use crate::common::set_fd_close_exec;
+use nix::sys::socket::{self};
+
+pub struct PipeListener {
+    fd: RawFd,
+    monitor_fd: (RawFd, RawFd),
+}
+
+impl AsRawFd for PipeListener {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl PipeListener {
+    pub(crate) fn new(sockaddr: &str) -> Result<PipeListener> {
+        let (fd, _) = common::do_bind(sockaddr)?;
+        common::do_listen(fd)?;
+
+        let fds = PipeListener::new_monitor_fd()?;
+
+        Ok(PipeListener {
+            fd,
+            monitor_fd: fds,
+        })
+    }
+
+    pub(crate) fn new_from_fd(fd: RawFd) -> Result<PipeListener> {
+        let fds = PipeListener::new_monitor_fd()?;
+
+        Ok(PipeListener {
+            fd,
+            monitor_fd: fds,
+        })
+    }
+
+    fn new_monitor_fd() ->  Result<(i32, i32)> {
+        #[cfg(target_os = "linux")]
+        let fds = pipe2(nix::fcntl::OFlag::O_CLOEXEC)?;
+ 
+        
+        #[cfg(target_os = "macos")] 
+        let fds = {
+            let (rfd, wfd) = pipe()?;
+            set_fd_close_exec(rfd)?;
+            set_fd_close_exec(wfd)?;
+            (rfd, wfd)
+        };
+
+        Ok(fds)
+    }
+
+    // accept returns:
+    // - Ok(Some(PipeConnection)) if a new connection is established
+    // - Ok(None) if spurious wake up with no new connection
+    // - Err(io::Error) if there is an error and listener loop should be shutdown
+    pub(crate) fn accept( &self, quit_flag: &Arc<AtomicBool>) ->  std::result::Result<Option<PipeConnection>, io::Error> {
+        if quit_flag.load(Ordering::SeqCst) {
+            return Err(io::Error::new(io::ErrorKind::Other, "listener shutdown for quit flag"));
+        }
+        
+        let mut pollers = vec![
+            libc::pollfd {
+                fd: self.monitor_fd.0,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: self.fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+
+        let returned = unsafe {
+            let pollers: &mut [libc::pollfd] = &mut pollers;
+            libc::poll(
+                pollers as *mut _ as *mut libc::pollfd,
+                pollers.len() as _,
+                -1,
+            )
+        };
+
+        if returned == -1 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                return Err(err);
+            }
+
+            error!("fatal error in listener_loop:{:?}", err);
+            return Err(err);
+        } else if returned < 1 {
+            return Ok(None)
+        }
+
+        if pollers[0].revents != 0 || pollers[pollers.len() - 1].revents == 0 {
+            return Ok(None);
+        }
+
+        if quit_flag.load(Ordering::SeqCst) {
+            return Err(io::Error::new(io::ErrorKind::Other, "listener shutdown for quit flag"));
+        }
+
+        #[cfg(target_os = "linux")]
+        let fd = match accept4(self.fd, SockFlag::SOCK_CLOEXEC) {
+            Ok(fd) => fd,
+            Err(e) => {
+                error!("failed to accept error {:?}", e);
+                return Err(std::io::Error::from_raw_os_error(e as i32));
+            }
+        };
+
+        // Non Linux platforms do not support accept4 with SOCK_CLOEXEC flag, so instead
+        // use accept and call fcntl separately to set SOCK_CLOEXEC.
+        // Because of this there is chance of the descriptor leak if fork + exec happens in between.
+        #[cfg(target_os = "macos")] 
+        let fd = match accept(self.fd) {
+            Ok(fd) => {
+                if let Err(err) = set_fd_close_exec(fd) {
+                    error!("fcntl failed after accept: {:?}", err);
+                    return Err(io::Error::new(io::ErrorKind::Other, format!("{err:?}")));
+                };
+                fd
+            }
+            Err(e) => {
+                error!("failed to accept error {:?}", e);
+                return Err(std::io::Error::from_raw_os_error(e as i32));
+            }
+        };
+
+
+        Ok(Some(PipeConnection { fd }))
+    }
+
+    pub fn close(&self) -> Result<()> {
+        close(self.monitor_fd.1).unwrap_or_else(|e| {
+            warn!(
+                "failed to close notify fd: {} with error: {}",
+                self.monitor_fd.1, e
+            )
+        });
+        Ok(())
+    }
+}
+
+
+pub struct PipeConnection {
+    fd: RawFd,
+}
+
+impl PipeConnection {
+    pub(crate) fn new(fd: RawFd) -> PipeConnection {
+        PipeConnection { fd }
+    }
+
+    pub(crate) fn id(&self) -> i32 {
+        self.fd
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        loop {
+            match  recv(self.fd, buf, MsgFlags::empty()) {
+                Ok(l) => return Ok(l),
+                Err(e) if retryable(e) => {
+                    // Should retry
+                    continue;
+                }
+                Err(e) => {
+                    return Err(crate::Error::Nix(e));
+                }
+            }
+        }
+    }
+
+    pub fn write(&self, buf: &[u8]) -> Result<usize> {
+        loop {
+            match send(self.fd, buf, MsgFlags::empty()) {
+                Ok(l) => return Ok(l),
+                Err(e) if retryable(e) => {
+                    // Should retry
+                    continue;
+                }
+                Err(e) => {
+                    return Err(crate::Error::Nix(e));
+                }
+            }
+        }
+    }
+
+    pub fn close(&self) -> Result<()> {
+        match close(self.fd) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(crate::Error::Nix(e))
+        }
+    }
+
+    pub fn shutdown(&self) -> Result<()> {
+        match socket::shutdown(self.fd, Shutdown::Read) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(crate::Error::Nix(e))
+        }
+    }
+}
+
+pub struct ClientConnection {
+    fd: RawFd,
+    socket_pair: (RawFd, RawFd),
+}
+
+impl ClientConnection {
+    pub fn client_connect(sockaddr: &str)-> Result<ClientConnection>   {
+        let fd = unsafe { client_connect(sockaddr)? };
+        Ok(ClientConnection::new(fd))
+    }
+
+    pub(crate) fn new(fd: RawFd) -> ClientConnection {
+        let (recver_fd, close_fd) =
+            socketpair(AddressFamily::Unix, SockType::Stream, None, SOCK_CLOEXEC).unwrap();
+
+        // MacOS doesn't support descriptor creation with SOCK_CLOEXEC automically,
+        // so there is a chance of leak if fork + exec happens in between of these calls.
+        #[cfg(target_os = "macos")]
+        {
+            set_fd_close_exec(recver_fd).unwrap();
+            set_fd_close_exec(close_fd).unwrap();
+        }
+
+
+        ClientConnection { 
+            fd, 
+            socket_pair: (recver_fd, close_fd) 
+        }
+    }
+
+    pub fn ready(&self) -> std::result::Result<Option<()>, io::Error> {
+        let mut pollers = vec![
+            libc::pollfd {
+                fd: self.socket_pair.0,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: self.fd,
+                events: libc::POLLIN,
+                revents: 0,
+            },
+        ];
+
+        let returned = unsafe {
+            let pollers: &mut [libc::pollfd] = &mut pollers;
+            libc::poll(
+                pollers as *mut _ as *mut libc::pollfd,
+                pollers.len() as _,
+                -1,
+            )
+        };
+
+        if returned == -1 {
+            let err = io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EINTR) {
+                return Ok(None)
+            }
+
+            error!("fatal error in process reaper:{}", err);
+            return Err(err);
+        } else if returned < 1 {
+            return Ok(None)
+        }
+
+        if pollers[0].revents != 0 {
+            return Err(io::Error::new(io::ErrorKind::Other, "pipe closed"));
+        }
+
+        if pollers[pollers.len() - 1].revents == 0 {
+            return Ok(None)
+        }
+
+        Ok(Some(()))
+    }
+
+    pub fn get_pipe_connection(&self) -> PipeConnection {
+        PipeConnection::new(self.fd)
+    }
+
+    pub fn close_receiver(&self) -> Result<()> {
+        match close(self.socket_pair.0) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(crate::Error::Nix(e))
+        }
+    }
+
+    pub fn close(&self) -> Result<()> {
+        match close(self.socket_pair.1) {
+            Ok(_) => {},
+            Err(e) => return Err(crate::Error::Nix(e))
+        };
+
+        match close(self.fd) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(crate::Error::Nix(e))
+        }
+    }
+}
+
+fn retryable(e: nix::Error) -> bool {
+    e == Error::EINTR || e == Error::EAGAIN
+}

--- a/src/sync/sys/windows/mod.rs
+++ b/src/sync/sys/windows/mod.rs
@@ -1,0 +1,2 @@
+mod net;
+pub use net::{PipeConnection, PipeListener, ClientConnection};

--- a/src/sync/sys/windows/net.rs
+++ b/src/sync/sys/windows/net.rs
@@ -1,0 +1,313 @@
+/*
+	Copyright The containerd Authors.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+*/
+
+use crate::error::Result;
+use crate::error::Error;
+use std::cell::UnsafeCell;
+use std::ffi::OsStr;
+use std::fs::OpenOptions;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::io::{IntoRawHandle};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc};
+use std::{io};
+
+use windows_sys::Win32::Foundation::{ CloseHandle, ERROR_IO_PENDING, ERROR_PIPE_CONNECTED, INVALID_HANDLE_VALUE };
+use windows_sys::Win32::Storage::FileSystem::{ ReadFile, WriteFile, FILE_FLAG_FIRST_PIPE_INSTANCE, FILE_FLAG_OVERLAPPED, PIPE_ACCESS_DUPLEX };
+use windows_sys::Win32::System::IO::{ GetOverlappedResult, OVERLAPPED };
+use windows_sys::Win32::System::Pipes::{ CreateNamedPipeW, ConnectNamedPipe,DisconnectNamedPipe, PIPE_WAIT, PIPE_UNLIMITED_INSTANCES, PIPE_REJECT_REMOTE_CLIENTS };
+use windows_sys::Win32::System::Threading::CreateEventW;
+
+const PIPE_BUFFER_SIZE: u32 = 65536;
+const WAIT_FOR_EVENT: i32 = 1;
+
+pub struct PipeListener {
+    first_instance: AtomicBool,
+    address: String,
+}
+
+#[repr(C)]
+struct Overlapped {
+    inner: UnsafeCell<OVERLAPPED>,
+}
+
+impl Overlapped {
+    fn new_with_event(event: isize) -> Overlapped  {        
+        let mut ol = Overlapped {
+            inner: UnsafeCell::new(unsafe { std::mem::zeroed() }),
+        };
+        ol.inner.get_mut().hEvent = event;
+        ol
+    }
+
+    fn new() -> Overlapped  {
+         Overlapped {
+             inner: UnsafeCell::new(unsafe { std::mem::zeroed() }),
+         }
+     }
+
+    fn as_mut_ptr(&self) -> *mut OVERLAPPED {
+        self.inner.get()
+    }
+}
+
+impl PipeListener {
+    pub(crate) fn new(sockaddr: &str) -> Result<PipeListener> {
+        Ok(PipeListener {
+            first_instance: AtomicBool::new(true),
+            address: sockaddr.to_string(),
+        })
+    }
+
+    // accept returns:
+    // - Ok(Some(PipeConnection)) if a new connection is established
+    // - Err(io::Error) if there is an error and listener loop should be shutdown
+    pub(crate) fn accept(&self, quit_flag: &Arc<AtomicBool>) -> std::result::Result<Option<PipeConnection>, io::Error> {
+        if quit_flag.load(Ordering::SeqCst) {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "listener shutdown for quit flag",
+            ));
+        }
+
+        // Create a new pipe instance for every new client
+        let np = self.new_instance().unwrap();
+        let ol = Overlapped::new();
+
+        trace!("listening for connection");
+        let result = unsafe { ConnectNamedPipe(np, ol.as_mut_ptr())};
+        if result != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        match io::Error::last_os_error() {
+            e if e.raw_os_error() == Some(ERROR_IO_PENDING as i32) => {
+                let mut bytes_transfered = 0;
+                let res = unsafe {GetOverlappedResult(np, ol.as_mut_ptr(), &mut bytes_transfered, WAIT_FOR_EVENT) };
+                match res {
+                    0 => {
+                        return Err(io::Error::last_os_error());
+                    }
+                    _ => {
+                        Ok(Some(PipeConnection::new(np)))
+                    }
+                }
+            }
+            e if e.raw_os_error() == Some(ERROR_PIPE_CONNECTED as i32) => {
+                Ok(Some(PipeConnection::new(np)))
+            }
+            e => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("failed to connect pipe: {:?}", e),
+                ));
+            }
+        }
+    }
+
+    fn new_instance(&self) -> io::Result<isize> {
+        let name = OsStr::new(&self.address.as_str())
+            .encode_wide()
+            .chain(Some(0)) // add NULL termination
+            .collect::<Vec<_>>();
+
+        let mut open_mode = PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED ;
+
+        if self.first_instance.load(Ordering::SeqCst) {
+            open_mode |= FILE_FLAG_FIRST_PIPE_INSTANCE;
+            self.first_instance.swap(false, Ordering::SeqCst);
+        }
+
+        // null for security attributes means the handle cannot be inherited and write access is restricted to system
+        // https://learn.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights
+        match  unsafe { CreateNamedPipeW(name.as_ptr(), open_mode, PIPE_WAIT | PIPE_REJECT_REMOTE_CLIENTS, PIPE_UNLIMITED_INSTANCES, PIPE_BUFFER_SIZE, PIPE_BUFFER_SIZE, 0, std::ptr::null_mut())} {
+            INVALID_HANDLE_VALUE => {
+                return Err(io::Error::last_os_error())
+            }
+            h => {
+                return Ok(h)
+            },
+        };
+    }
+
+    pub fn close(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct PipeConnection {
+    named_pipe: isize,
+    read_event: isize,
+    write_event: isize,
+}
+
+// PipeConnection on Windows is used by both the Server and Client to read and write to the named pipe
+// The named pipe is created with the overlapped flag enable the simultaneous read and write operations.
+// This is required since a read and write be issued at the same time on a given named pipe instance.
+//
+// An event is created for the read and write operations.  When the read or write is issued
+// it either returns immediately or the thread is suspended until the event is signaled when 
+// the overlapped (async) operation completes and the event is triggered allow the thread to continue.
+// 
+// Due to the implementation of the sync Server and client there is always only one read and one write 
+// operation in flight at a time so we can reuse the same event.
+// 
+// For more information on overlapped and events: https://learn.microsoft.com/en-us/windows/win32/api/ioapiset/nf-ioapiset-getoverlappedresult#remarks
+// "It is safer to use an event object because of the confusion that can occur when multiple simultaneous overlapped operations are performed on the same file, named pipe, or communications device." 
+// "In this situation, there is no way to know which operation caused the object's state to be signaled."
+impl PipeConnection {
+    pub(crate) fn new(h: isize) -> PipeConnection {
+        trace!("creating events for thread {:?} on pipe instance {}", std::thread::current().id(), h as i32);
+        let read_event = unsafe { CreateEventW(std::ptr::null_mut(), 0, 1, std::ptr::null_mut()) };
+        let write_event = unsafe { CreateEventW(std::ptr::null_mut(), 0, 1, std::ptr::null_mut()) };
+        PipeConnection {
+            named_pipe: h,
+            read_event: read_event,
+            write_event: write_event,
+        }
+    }
+
+    pub(crate) fn id(&self) -> i32 {
+        self.named_pipe as i32
+    }
+
+    pub fn read(&self, buf: &mut [u8]) -> Result<usize> {
+        trace!("starting read for thread {:?} on pipe instance {}", std::thread::current().id(), self.named_pipe as i32);
+        let ol = Overlapped::new_with_event(self.read_event);
+
+        let len = std::cmp::min(buf.len(), u32::MAX as usize) as u32;
+        let mut bytes_read= 0;
+        let result = unsafe { ReadFile(self.named_pipe, buf.as_mut_ptr() as *mut _, len, &mut bytes_read,ol.as_mut_ptr()) };
+        if result > 0 && bytes_read > 0 {
+            // Got result no need to wait for pending read to complete
+            return Ok(bytes_read as usize)
+        }
+
+        // wait for pending operation to complete (thread will be suspended until event is signaled)
+        match io::Error::last_os_error() {
+            ref e if e.raw_os_error() == Some(ERROR_IO_PENDING as i32) => {
+                let mut bytes_transfered = 0;
+                let res = unsafe {GetOverlappedResult(self.named_pipe, ol.as_mut_ptr(), &mut bytes_transfered, WAIT_FOR_EVENT) };
+                match res {
+                    0 => {
+                        return Err(Error::Windows(io::Error::last_os_error().raw_os_error().unwrap()))
+                    }
+                    _ => {
+                        return Ok(bytes_transfered as usize)
+                    }
+                }
+            }
+            ref e => {
+                return Err(Error::Others(format!("failed to read from pipe: {:?}", e)))
+            }
+        }
+    }
+
+    pub fn write(&self, buf: &[u8]) -> Result<usize> {
+        trace!("starting write for thread {:?} on pipe instance {}", std::thread::current().id(), self.named_pipe as i32);
+        let ol = Overlapped::new_with_event(self.write_event);
+        let mut bytes_written = 0;
+        let len = std::cmp::min(buf.len(), u32::MAX as usize) as u32;
+        let result = unsafe { WriteFile(self.named_pipe, buf.as_ptr() as *const _,len, &mut bytes_written, ol.as_mut_ptr())};
+        if result > 0 && bytes_written > 0 {
+            // No need to wait for pending write to complete
+            return Ok(bytes_written as usize)
+        }
+
+        // wait for pending operation to complete (thread will be suspended until event is signaled)
+        match io::Error::last_os_error() {
+            ref e if e.raw_os_error() == Some(ERROR_IO_PENDING as i32) => {
+                let mut bytes_transfered = 0;
+                let res = unsafe {GetOverlappedResult(self.named_pipe, ol.as_mut_ptr(), &mut bytes_transfered, WAIT_FOR_EVENT) };
+                match res {
+                    0 => {
+                        return Err(Error::Windows(io::Error::last_os_error().raw_os_error().unwrap()))
+                    }
+                    _ => {
+                        return Ok(bytes_transfered as usize)
+                    }
+                }
+            }
+            ref e => {
+                return Err(Error::Others(format!("failed to write to pipe: {:?}", e)))
+            }
+        }
+    }
+
+    pub fn close(&self) -> Result<()> {
+        close_handle(self.named_pipe)?;
+        close_handle(self.read_event)?;
+        close_handle(self.write_event)
+    }
+
+    pub fn shutdown(&self) -> Result<()> {
+        let result = unsafe { DisconnectNamedPipe(self.named_pipe) };
+        match result {
+            0 => Err(Error::Windows(io::Error::last_os_error().raw_os_error().unwrap())),
+            _ => Ok(()),
+        }
+    }
+}
+
+pub struct ClientConnection {
+    address: String
+}
+
+fn close_handle(handle: isize) -> Result<()> {
+    let result = unsafe { CloseHandle(handle) };
+    match result {
+        0 => Err(Error::Windows(io::Error::last_os_error().raw_os_error().unwrap())),
+        _ => Ok(()),
+    }
+}
+
+impl ClientConnection {
+    pub fn client_connect(sockaddr: &str) -> Result<ClientConnection> {
+        Ok(ClientConnection::new(sockaddr))
+    }
+
+    pub(crate) fn new(sockaddr: &str) -> ClientConnection {       
+        ClientConnection {
+            address: sockaddr.to_string()
+        }
+    }
+
+    pub fn ready(&self) -> std::result::Result<Option<()>, io::Error> {
+        // Windows is a "completion" based system so "readiness" isn't really applicable 
+        Ok(Some(()))
+    }
+
+    pub fn get_pipe_connection(&self) -> PipeConnection {
+        let mut opts = OpenOptions::new();
+        opts.read(true)
+            .write(true)
+            .custom_flags(FILE_FLAG_OVERLAPPED);
+        let file = opts.open(self.address.as_str());
+
+        PipeConnection::new(file.unwrap().into_raw_handle() as isize)
+    }
+
+    pub fn close_receiver(&self) -> Result<()> {
+        // close the pipe from the pipe connection
+        Ok(())
+    }
+
+    pub fn close(&self) -> Result<()> {
+        // close the pipe from the pipe connection
+        Ok(())
+    }
+}

--- a/src/sync/utils.rs
+++ b/src/sync/utils.rs
@@ -97,7 +97,10 @@ macro_rules! client_request {
 /// The context of ttrpc (sync).
 #[derive(Debug)]
 pub struct TtrpcContext {
+    #[cfg(unix)]
     pub fd: std::os::unix::io::RawFd,
+    #[cfg(windows)]
+    pub fd: i32,
     pub mh: MessageHeader,
     pub res_tx: std::sync::mpsc::Sender<(MessageHeader, Vec<u8>)>,
     pub metadata: HashMap<String, Vec<String>>,

--- a/tests/sync-test.rs
+++ b/tests/sync-test.rs
@@ -1,0 +1,61 @@
+use std::{
+    io::{BufRead, BufReader},
+    process::Command,
+    time::Duration,
+};
+
+#[test]
+fn run_sync_example() -> Result<(), Box<dyn std::error::Error>> {
+    // start the server and give it a moment to start.
+    let mut server = run_example("server").spawn().unwrap();
+    std::thread::sleep(Duration::from_secs(2));
+
+    let mut client = run_example("client").spawn().unwrap();
+    let mut client_succeeded = false;
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(600);
+    loop {
+        if start.elapsed() > timeout {
+            println!("Running the client timed out. output:");
+            client.kill().unwrap_or_else(|e| {
+                println!("This may occur on Windows if the process has exited: {e}");
+            });
+            let output = client.stdout.unwrap();
+            BufReader::new(output).lines().for_each(|line| {
+                println!("{}", line.unwrap());
+            });
+            break;
+        }
+
+        match client.try_wait() {
+            Ok(Some(status)) => {
+                client_succeeded = status.success();
+                break;
+            }
+            Ok(None) => {
+                // still running
+                continue;
+            }
+            Err(e) => {
+                println!("Error: {e}");
+                break;
+            }
+        }
+    }
+
+    // be sure to clean up the server, the client should have run to completion
+    server.kill()?;
+    assert!(client_succeeded);
+    Ok(())
+}
+
+fn run_example(example: &str) -> Command {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("run")
+        .arg("--example")
+        .arg(example)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .current_dir("example");
+    cmd
+}


### PR DESCRIPTION
Fixes: #132 

This PR adds initial support for Windows.  The scope is fairly large, so it only adds support for `sync` implementation to keep it fairly reasonable 😬. It would be possible to split out some parts of the work into smaller PR's or commits as needed. I have two main commits but happy to make them more distinct.  It also has all the changes from #171 so I can drop those once that merges 👍 

Note: I am fairly new to Rust so might need some guidance on choices I made here. There is still some more work to be done (adding security file descriptors to named pipe for instance) in the PR but wanted to get it open for discussion on the general direction.

This PR does three main things:

- moves unix specific calls out of the main server and client functions.  It does this by introducing several new types: `PipeListener`, `PipeConnection`, and `ClientConnection`.  These types contain the unix specific functionality to communicate with Unix Domain sockets and are hidden behind a conditional compilation flag for the OS target.  
- Adds the windows functionality for `PipeListener`, `PipeConnection`, and `ClientConnection` and does the few other changes required to build and run the example projects. This includes adding feature support to the examples so they wouldn't build the `async` projects (as the unix specific code hasn't been removed yet). Importantly I avoided changes to the code generation and service api, so there are minimal changes to the example code beyond changing the socket address to a namedpipe format.
- Add windows build agents and modifies the example so it runs in an integration test using `cargo test`.  This seemed like a good way to ensure the whole system (code generation, client build and sever/client) worked e2e for all the OSes.

Another thing to note is that this PR implements Windows support using named pipes.  While windows does have a UDS implementation, Containerd does not currently support this. As one of the main uses for this is containerd so adding namedpipe support is needed.