### PR TITLE
ci: Separate CI testing to Check and Build

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -1,8 +1,8 @@
 name: BVT
 on: [pull_request]
 jobs:
-  make:
-    name: Make
+  check:
+    name: Check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -10,29 +10,29 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Make
+      - name: Check
         run: |
           make deps
-          make
-          make -C example deps
-          make -C example
-          make -C ttrpc-codegen deps
-          make -C ttrpc-codegen
+          make check
+          make -C compiler check
+          make -C ttrpc-codegen check
 
-  clippy_check:
-    name: Clippy Check
+  make:
+    name: Build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v3
-      - run: rustup component add clippy
-      - uses: tim-actions/clippy-check@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
-          name: checks-${{ matrix.os }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build
+        run: |
+          make deps
+          make
+          make -C compiler
+          make -C ttrpc-codegen
+          make -C example build-examples
 
   deny:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: debug check test
+all: debug test
 
 #
 # Build

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -15,13 +15,9 @@ release:
 .PHONY: build
 build: debug
 
-#
-# Tests and linters
-#
-
 .PHONY: test
 test:
-	cargo test --verbose
+	cargo test --all-features --verbose
 
 .PHONY: check
 check:

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -48,7 +48,7 @@ impl<'a> Iterator for NameSpliter<'a> {
         let mut meet_lower = false;
         for i in self.pos..self.name.len() {
             let c = self.name[i];
-            if b'A' <= c && c <= b'Z' {
+            if (b'A'..=b'Z').contains(&c) {
                 if meet_lower {
                     // So it should be AaA or aaA
                     pos = i;
@@ -171,7 +171,7 @@ mod test {
         ];
 
         for (origin, exp) in cases {
-            let res = super::to_snake_case(&origin);
+            let res = super::to_snake_case(origin);
             assert_eq!(res, exp);
         }
     }
@@ -193,7 +193,7 @@ mod test {
         ];
 
         for (origin, exp) in cases {
-            let res = super::to_camel_case(&origin);
+            let res = super::to_camel_case(origin);
             assert_eq!(res, exp);
         }
     }

--- a/example/Makefile
+++ b/example/Makefile
@@ -4,6 +4,10 @@
 
 .PHONY: build
 build:
+	cargo build
+
+.PHONY: build-examples
+build-examples: build
 	cargo build --example server
 	cargo build --example client
 	cargo build --example async-server


### PR DESCRIPTION
ci: Separate CI testing to Check and Build

Disable the duplicated CI testing named "Clippy Check", and separate the Build action into two parts: "Check" and "Build".

Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>