### PR TITLE
[Windows] Check for errors when connecting with client

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -19,7 +19,7 @@ use std::result;
 use thiserror::Error;
 
 /// The error type for ttrpc.
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum Error {
     #[error("socket err: {0}")]
     Socket(String),


### PR DESCRIPTION
The `unwrap()` on the file when creating the client connection causes a panic.  This can happen if the file doesn't exist or there is a small chance when multiple clients connect quickly that the pipe returns 'All pipe instances are busy.' also causing a panic.  This allows the caller to handle these errors and retry if necessary (as is the case with the pipe instances being busy).