### PR TITLE
MAINTAINERS: add Tim Zhang and Lei Wang as member

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,6 +1,11 @@
 # ttrpc-rust project maintainers
 #
-# MAINTAINERS
+# COMMITTERS
 # GitHub ID, Name, Email address
 teawater, Hui Zhu, teawater@antfin.com
 lifupan, Fupan Li, fupan.lfp@alibaba-inc.com
+Tim-Zhang, Tim Zhang, tim@hyper.sh
+
+# REVIEWERS
+# GitHub ID, Name, Email address
+wllenyj, Lei Wang, wllenyj@linux.alibaba.com


### PR DESCRIPTION
Tim Zhang(@Tim-Zhang) has meaningful contribution to the project and is
the maintainer of project as collaborator. He should be added as member
officially. I'd like to add him as COMMITTER.

And Lei Wang(@wllenyj) has been a active reviewer, but he is still
collaborator. He should be added as member as well. So, I'd like to add
him as REVIEWER.

Needs explicit LGTM from:

* [x] @Tim-Zhang 
* [x] @wllenyj 

Signed-off-by: Wei Fu <fuweid89@gmail.com>

---------

@containerd/committers @teawater @lifupan 