### PR TITLE
Update client::new to return Result<Client>

### DIFF
--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -50,20 +50,7 @@ impl Client {
 
     #[cfg(unix)]
     /// Initialize a new [`Client`] from raw file descriptor.
-    #[deprecated(since="0.8.0", note="please use `new_from_fd` instead")]
-    pub fn new(fd: RawFd) -> Client {
-        let conn = ClientConnection::new(fd);
-
-        Self::new_client(conn).unwrap_or_else(|e| {
-            panic!(
-                "client was not successfully initialized: {}", e
-            )
-        })
-    }
-
-    #[cfg(unix)]
-    /// Initialize a new [`Client`] from raw file descriptor.
-    pub fn new_from_fd(fd: RawFd) -> Result<Client> {
+    pub fn new(fd: RawFd) -> Result<Client> {
         let conn = ClientConnection::new(fd);
 
         Self::new_client(conn)


### PR DESCRIPTION
When introducing Windows support the client creation resulted in a Result<Client> being returned. This a breaking update for client::new in the client API.

Follow up to https://github.com/containerd/ttrpc-rust/pull/181 and https://github.com/containerd/ttrpc-rust/pull/190#issuecomment-1576001447