### PR TITLE
[0.5.0] Backport features about async-client's sending requests via a `&Client`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -12,11 +12,11 @@ use ttrpc::r#async::Client;
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let c = Client::connect("unix:///tmp/1").unwrap();
-    let mut hc = health_ttrpc::HealthClient::new(c.clone());
-    let mut ac = agent_ttrpc::AgentServiceClient::new(c);
+    let hc = health_ttrpc::HealthClient::new(c.clone());
+    let ac = agent_ttrpc::AgentServiceClient::new(c);
 
-    let mut thc = hc.clone();
-    let mut tac = ac.clone();
+    let thc = hc.clone();
+    let tac = ac.clone();
 
     let now = std::time::Instant::now();
 

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -147,7 +147,7 @@ impl Client {
         Client { req_tx }
     }
 
-    pub async fn request(&mut self, req: Request) -> Result<Response> {
+    pub async fn request(&self, req: Request) -> Result<Response> {
         let mut buf = Vec::with_capacity(req.compute_size() as usize);
         {
             let mut s = CodedOutputStream::vec(&mut buf);

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ttrpc-codegen"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2018"
 authors = ["The AntFin Kata Team <kata@list.alibaba-inc.com>"]
 license = "Apache-2.0"

--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -18,4 +18,4 @@ protobuf = "2.28.0"
 protobuf-codegen = { package = "protobuf-codegen3", version = "2.28.2" }
 # protobuf-codegen-pure3 is a protobuf-codegen-pure version that supports proto3 optional fields
 protobuf-codegen-pure = { package = "protobuf-codegen-pure3", version = "2.28.2" }
-ttrpc-compiler = "0.4.3"
+ttrpc-compiler = "0.4.4"


### PR DESCRIPTION
This pull request includes following releases:
- ttrpc-codegen v0.2.4
- ttrpc v0.5.4 