### PR TITLE
stream: Fix default data won't be received issue

### DIFF
--- a/example/protocols/protos/streaming.proto
+++ b/example/protocols/protos/streaming.proto
@@ -32,6 +32,7 @@ service Streaming {
 	rpc DivideStream(Sum) returns (stream Part);
 	rpc EchoNull(stream EchoPayload) returns (google.protobuf.Empty);
 	rpc EchoNullStream(stream EchoPayload) returns (stream google.protobuf.Empty);
+	rpc EchoDefaultValue(EchoPayload) returns (stream EchoPayload);
 }
 
 message EchoPayload {


### PR DESCRIPTION
Protobuf encodes default values, e.g., 0 for number, "" for string, as empty payload and we wouldn't send empty payload to a receiver.

This commit change the method of empty message detecting.

Fixes #169
Fixes #207