### PR TITLE
[0.6.0] docs: remove feature protobuf-codec

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -7,6 +7,7 @@ fn main() {
     let path: PathBuf = [out_dir.clone(), "mod.rs".to_string()].iter().collect();
     fs::write(path, "pub mod ttrpc;").unwrap();
 
+    #[allow(clippy::needless_borrow)]
     protobuf_codegen_pure::Codegen::new()
         .out_dir(out_dir)
         .inputs(&["src/ttrpc.proto"])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //!
 //! - `async`: Enables async server and client.
 //! - `sync`: Enables traditional sync server and client (default enabled).
-//! - `protobuf-codec`: Includes rust-protobuf (default enabled).
 //!
 //! # Socket address
 //!


### PR DESCRIPTION
Which does not exist anymore.