### PR TITLE
Handle OS Interruptions

### DIFF
--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -363,6 +363,10 @@ impl Server {
                             continue;
                         }
                         Ok(Some(conn)) => Arc::new(conn),
+                        Err(e) if e.kind() == std::io::ErrorKind::Interrupted => {
+                            error!("got interruption {:?}.  Continue...", e);
+                            continue;
+                        }
                         Err(e) => {
                             error!("listener accept got {:?}", e);
                             break;


### PR DESCRIPTION
When running on MacOs we found a bug:

```
Dec 12 18:45:42 spin-oci-worker containerd[102]: time="2023-12-12T18:45:42.523982005Z" level=info msg="Shim successfully started, waiting for exit signal..."
Dec 12 18:45:42 spin-oci-worker containerd[102]: time="2023-12-12T18:45:42.533327005Z" level=error msg="listener accept got Os { code: 4, kind: Interrupted, message: "Interrupted system call" }"
Dec 12 18:45:42 spin-oci-worker containerd[102]: time="2023-12-12T18:45:42.535132005Z" level=info msg="ttrpc server listener stopped"
```

This will retry the connection.  I don't have a Mac to test this on but wanted to open it up for feedback incase others are seeing the error