### PR TITLE
bugfix: still check request payload

### DIFF
--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -628,7 +628,7 @@ impl HandlerContext {
 
         let task = spawn(async move { stream.handler(ctx, si).await });
 
-        if !no_data {
+        if !no_data && !req.payload.is_empty() {
             // Fake the first data message.
             let msg = GenMessage {
                 header: MessageHeader::new_data(stream_id, req.payload.len() as u32),


### PR DESCRIPTION
the ttrpc golang do not send flagNodata in the request even it is an empty request.

fix #221 