### PR TITLE
Codegen: convert Arc<Box<T>> to Arc<T>

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -145,7 +145,7 @@ impl<'a> MethodGen<'a> {
             "}",
             |w| {
                 w.write_line(&format!(
-                    "service: Arc<Box<dyn {} + Send + Sync>>,",
+                    "service: Arc<dyn {} + Send + Sync>,",
                     self.service_name
                 ));
             },
@@ -558,7 +558,7 @@ impl<'a> ServiceGen<'a> {
     fn write_sync_server_create(&self, w: &mut CodeWriter) {
         let method_handler_name = "::ttrpc::MethodHandler";
         let s = format!(
-            "create_{}(service: Arc<Box<dyn {} + Send + Sync>>) -> HashMap<String, Box<dyn {} + Send + Sync>>",
+            "create_{}(service: Arc<dyn {} + Send + Sync>) -> HashMap<String, Box<dyn {} + Send + Sync>>",
             to_snake_case(&self.service_name()),
             self.service_name(),
             method_handler_name,
@@ -577,7 +577,7 @@ impl<'a> ServiceGen<'a> {
 
     fn write_async_server_create(&self, w: &mut CodeWriter) {
         let s = format!(
-            "create_{}(service: Arc<Box<dyn {} + Send + Sync>>) -> HashMap<String, {}>",
+            "create_{}(service: Arc<dyn {} + Send + Sync>) -> HashMap<String, {}>",
             to_snake_case(&self.service_name()),
             self.service_name(),
             "::ttrpc::r#async::Service"
@@ -642,7 +642,6 @@ fn write_generated_common(w: &mut CodeWriter) {
     w.write_line("#![cfg_attr(rustfmt, rustfmt_skip)]");
     w.write_line("#![allow(unknown_lints)]");
     w.write_line("#![allow(clipto_camel_casepy)]");
-    w.write_line("#![allow(box_pointers)]");
     w.write_line("#![allow(dead_code)]");
     w.write_line("#![allow(missing_docs)]");
     w.write_line("#![allow(non_camel_case_types)]");

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -51,3 +51,7 @@ path = "./async-stream-client.rs"
 
 [build-dependencies]
 ttrpc-codegen = { path = "../ttrpc-codegen"}
+
+[patch.crates-io]
+ttrpc-compiler = { path = "../compiler"}
+

--- a/example/async-client.rs
+++ b/example/async-client.rs
@@ -6,7 +6,7 @@
 mod protocols;
 mod utils;
 #[cfg(unix)]
-use protocols::r#async::{agent, agent_ttrpc, health, health_ttrpc};
+use protocols::asynchronous::{agent, agent_ttrpc, health, health_ttrpc};
 use ttrpc::context::{self, Context};
 #[cfg(unix)]
 use ttrpc::r#async::Client;

--- a/example/async-server.rs
+++ b/example/async-server.rs
@@ -14,7 +14,7 @@ use std::sync::Arc;
 use log::LevelFilter;
 
 #[cfg(unix)]
-use protocols::r#async::{agent, agent_ttrpc, health, health_ttrpc, types};
+use protocols::asynchronous::{agent, agent_ttrpc, health, health_ttrpc, types};
 #[cfg(unix)]
 use ttrpc::asynchronous::Server;
 use ttrpc::error::{Error, Result};
@@ -97,13 +97,8 @@ fn main() {
 async fn main() {
     simple_logging::log_to_stderr(LevelFilter::Trace);
 
-    let h = Box::new(HealthService {}) as Box<dyn health_ttrpc::Health + Send + Sync>;
-    let h = Arc::new(h);
-    let hservice = health_ttrpc::create_health(h);
-
-    let a = Box::new(AgentService {}) as Box<dyn agent_ttrpc::AgentService + Send + Sync>;
-    let a = Arc::new(a);
-    let aservice = agent_ttrpc::create_agent_service(a);
+    let hservice = health_ttrpc::create_health(Arc::new(HealthService {}));
+    let aservice = agent_ttrpc::create_agent_service(Arc::new(AgentService {}));
 
     utils::remove_if_sock_exist(utils::SOCK_ADDR).unwrap();
 

--- a/example/async-stream-client.rs
+++ b/example/async-stream-client.rs
@@ -6,7 +6,7 @@
 mod protocols;
 mod utils;
 #[cfg(unix)]
-use protocols::r#async::{empty, streaming, streaming_ttrpc};
+use protocols::asynchronous::{empty, streaming, streaming_ttrpc};
 use ttrpc::context::{self, Context};
 #[cfg(unix)]
 use ttrpc::r#async::Client;

--- a/example/async-stream-server.rs
+++ b/example/async-stream-server.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use log::{info, LevelFilter};
 
 #[cfg(unix)]
-use protocols::r#async::{empty, streaming, streaming_ttrpc};
+use protocols::asynchronous::{empty, streaming, streaming_ttrpc};
 #[cfg(unix)]
 use ttrpc::{asynchronous::Server, Error};
 
@@ -163,11 +163,7 @@ fn main() {
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     simple_logging::log_to_stderr(LevelFilter::Info);
-
-    let s = Box::new(StreamingService {}) as Box<dyn streaming_ttrpc::Streaming + Send + Sync>;
-    let s = Arc::new(s);
-    let service = streaming_ttrpc::create_streaming(s);
-
+    let service = streaming_ttrpc::create_streaming(Arc::new(StreamingService {}));
     utils::remove_if_sock_exist(utils::SOCK_ADDR).unwrap();
 
     let mut server = Server::new()

--- a/example/protocols/mod.rs
+++ b/example/protocols/mod.rs
@@ -4,6 +4,4 @@
 //
 #[cfg(unix)]
 pub mod asynchronous;
-#[cfg(unix)]
-pub use asynchronous as r#async;
 pub mod sync;

--- a/example/server.rs
+++ b/example/server.rs
@@ -81,14 +81,8 @@ impl agent_ttrpc::AgentService for AgentService {
 
 fn main() {
     simple_logging::log_to_stderr(LevelFilter::Trace);
-
-    let h = Box::new(HealthService {}) as Box<dyn health_ttrpc::Health + Send + Sync>;
-    let h = Arc::new(h);
-    let hservice = health_ttrpc::create_health(h);
-
-    let a = Box::new(AgentService {}) as Box<dyn agent_ttrpc::AgentService + Send + Sync>;
-    let a = Arc::new(a);
-    let aservice = agent_ttrpc::create_agent_service(a);
+    let hservice = health_ttrpc::create_health(Arc::new(HealthService {}));
+    let aservice = agent_ttrpc::create_agent_service(Arc::new(AgentService {}));
 
     utils::remove_if_sock_exist(utils::SOCK_ADDR).unwrap();
     let mut server = Server::new()


### PR DESCRIPTION
This commit changes the generated ttrpc server from Arc<Box<T>> to Arc<T>. This helps the type conversion and also avoids extra runtime cost caused by double pointer.

Fixes #234