### PR TITLE
server: fix server exit once a accept failed

### DIFF
--- a/src/sync/server.rs
+++ b/src/sync/server.rs
@@ -427,7 +427,7 @@ impl Server {
                         Ok(fd) => fd,
                         Err(e) => {
                             error!("failed to accept error {:?}", e);
-                            break;
+                            continue;
                         }
                     };
 
@@ -439,13 +439,13 @@ impl Server {
                         Ok(fd) => {
                             if let Err(err) = set_fd_close_exec(fd) {
                                 error!("fcntl failed after accept: {:?}", err);
-                                break;
+                                continue;
                             };
                             fd
                         }
                         Err(e) => {
                             error!("failed to accept error {:?}", e);
-                            break;
+                            continue;
                         }
                     };
 


### PR DESCRIPTION
If the Accept error occurs, an error can be output to ensure that the subsequent connect can be accepted normally.

Fixes: #239