### PR TITLE
Update timeout to infinite for poll of accept

### DIFF
--- a/src/sync/sys/unix/net.rs
+++ b/src/sync/sys/unix/net.rs
@@ -101,7 +101,7 @@ impl PipeListener {
             libc::poll(
                 pollers as *mut _ as *mut libc::pollfd,
                 pollers.len() as _,
-                POLL_MAX_TIME,
+                -1,
             )
         };
 


### PR DESCRIPTION
It should be a mistake to modify it from -1 to 10
in the PR #226
https://github.com/containerd/ttrpc-rust/pull/226/files#diff-e74ddb472174f24fb4713f5a2fe2d33bbc5db28ee2a5c7dad1ea9025b897e8a5R110

There already are monitor_fd to notify exit, so accept without timeout is safe.