### PR TITLE
clippy: fix warnings for redundant field names in struct initialization

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -505,7 +505,7 @@ impl<'a> ServiceGen<'a> {
         w.impl_self_block(&self.client_name(), |w| {
             w.pub_fn("new(client: ::ttrpc::Client) -> Self", |w| {
                 w.expr_block(&self.client_name(), |w| {
-                    w.field_entry("client", "client");
+                    w.write_line("client,");
                 });
             });
 
@@ -527,7 +527,7 @@ impl<'a> ServiceGen<'a> {
         w.impl_self_block(&self.client_name(), |w| {
             w.pub_fn("new(client: ::ttrpc::r#async::Client) -> Self", |w| {
                 w.expr_block(&self.client_name(), |w| {
-                    w.field_entry("client", "client");
+                    w.write_line("client,");
                 });
             });
 


### PR DESCRIPTION
Refactor codegen.rs to use write_line instead of field_entry for client initialization.

An example of this:
```
warning: redundant field names in struct initialization
  --> xxx_ttrpc.rs
   |
   |             client: client,
   |             ^^^^^^^^^^^^^^ help: replace it with: `client`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#redundant_field_names
   = note: `#[warn(clippy::redundant_field_names)]` on by default
```