### PR TITLE
ttrpc-codegen: bump protobuf-codegen to 3.5.1

### DIFF
--- a/ttrpc-codegen/Cargo.toml
+++ b/ttrpc-codegen/Cargo.toml
@@ -17,5 +17,5 @@ readme = "README.md"
 home = "=0.5.9"
 protobuf-support = "3.2.0"
 protobuf = { version = "2.27.1" }
-protobuf-codegen = "3.2.0"
+protobuf-codegen = "3.5.1"
 ttrpc-compiler = "0.6.1"


### PR DESCRIPTION
Fixes: https://github.com/stepancheg/rust-protobuf/pull/733