### PR TITLE
Do not setsockopt(2) on AF_UNIX / AF_VSOCK sockets

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -172,7 +172,6 @@ fn make_socket(sockaddr: &str) -> Result<(RawFd, Domain, Box<dyn SockaddrLike>)>
 pub(crate) fn do_bind(sockaddr: &str) -> Result<(RawFd, Domain)> {
     let (fd, domain, sockaddr) = make_socket(sockaddr)?;
 
-    setsockopt(fd, sockopt::ReusePort, &true)?;
     bind(fd, sockaddr.as_ref()).map_err(err_to_others_err!(e, ""))?;
 
     Ok((fd, domain))


### PR DESCRIPTION
With Linux 6.12, specifically this commit:
https://github.com/torvalds/linux/commit/5b0af621c3f6ef9261cf6067812f2fd9943acb4b, one can not call `setsockopt(2)` on non-inet (`AF_INET`/`AF_INET6`) sockets anymore. As the ttRPC socket can only ever be non-inet, we should not ever call `setsockopt(2)` here.