### PR TITLE
compiler: write_async_server_create: Fix no methods mut issue

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -486,6 +486,12 @@ impl<'a> ServiceGen<'a> {
             .any(|method| !matches!(method.method_type().0, MethodType::Unary))
     }
 
+    fn has_normal_method(&self) -> bool {
+        self.methods
+            .iter()
+            .any(|method| matches!(method.method_type().0, MethodType::Unary))
+    }
+
     fn write_client(&self, w: &mut CodeWriter) {
         if async_on(self.customize, "client") {
             self.write_async_client(w)
@@ -588,9 +594,14 @@ impl<'a> ServiceGen<'a> {
         );
 
         let has_stream_method = self.has_stream_method();
+        let has_normal_method = self.has_normal_method();
         w.pub_fn(&s, |w| {
             w.write_line("let mut ret = HashMap::new();");
-            w.write_line("let mut methods = HashMap::new();");
+            if has_normal_method {
+                w.write_line("let mut methods = HashMap::new();");
+            } else {
+                w.write_line("let methods = HashMap::new();");
+            }
             if has_stream_method {
                 w.write_line("let mut streams = HashMap::new();");
             } else {

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -574,8 +574,13 @@ impl<'a> ServiceGen<'a> {
             method_handler_name,
         );
 
+        let has_normal_method = self.has_normal_method();
         w.pub_fn(&s, |w| {
-            w.write_line("let mut methods = HashMap::new();");
+            if has_normal_method {
+                w.write_line("let mut methods = HashMap::new();");
+            } else {
+                w.write_line("let methods = HashMap::new();");
+            }
             for method in &self.methods[0..self.methods.len()] {
                 w.write_line("");
                 method.write_bind(w);


### PR DESCRIPTION
Got follow build issue with a service that doesn't have normal methods and just has stream methods:
error: variable does not need to be mutable
  -->
/home/t4/teawater/coco/kata-containers/src/libs/protocols/src/attestation_agent_ttrpc.rs:60:9
   |
60 |     let mut methods = HashMap::new();
   |         ----^^^^^^^
   |         |
   |         help: remove this `mut`
   |
   = note: `-D unused-mut` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unused_mut)]`
The reason is the code that generate from proto file is:
    let mut methods = HashMap::new();
    let mut streams = HashMap::new();

    streams.insert("ContainerEventsStream".to_string(),
                    Arc::new(ContainerEventsStreamMethod{service:
service.clone()}) as Arc<dyn ::ttrpc::r#async::StreamHandler + Send + Sync>);

    ret.insert("grpc.AttestationAgent".to_string(),
::ttrpc::r#async::Service{ methods, streams });
    ret

This commit update function write_async_server_create to handle this issue.

Fixes: #273