### PR TITLE
add accept method

### DIFF
--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -171,6 +171,15 @@ impl Server {
         Ok(())
     }
 
+    pub async fn accept(&mut self, conn: Socket) -> std::io::Result<()> {
+        let delegate = ServerBuilder {
+            services: self.services.clone(),
+            streams: Arc::default(),
+            shutdown_waiter: self.shutdown.subscribe(),
+        };
+        Connection::new(conn, delegate).run().await
+    }
+
     pub async fn shutdown(&mut self) -> Result<()> {
         self.stop_listen().await;
         self.disconnect().await;


### PR DESCRIPTION
For my NRI plugin I only have a single connection. Wrapping that connection into a stream is possible, but comes with some significant disadvantages. The first being that the spawning hides any potential errors, the other my multiplexer needs to have a 'static lifetime. With the given PR a new method is introduced that directly runs the connection without "accepting" a new connection from the stream, thus allowing direct control over the threading and error handling.

Fixes #293 