### PR TITLE
Bugfix: fix panic caused by fd limit reached during new ClientConnection

### DIFF
--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -55,7 +55,8 @@ impl Client {
     #[cfg(unix)]
     /// Initialize a new [`Client`] from raw file descriptor.
     pub fn new(fd: RawFd) -> Result<Client> {
-        let conn = ClientConnection::new(fd);
+        let conn =
+            ClientConnection::new(fd).map_err(err_to_others_err!(e, "new ClientConnection"))?;
 
         Self::new_client(conn)
     }


### PR DESCRIPTION
Fixed issue where reaching the file descriptor limit (EMFILE) during ClientConnection creation could lead to unexpected process termination.