### PR TITLE
fix(sync): Avoid panic when using sync client from a GCC destructor

### DIFF
--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -169,28 +169,33 @@ impl Client {
             .send((buf, tx))
             .map_err(err_to_others_err!(e, "Send packet to sender error "))?;
 
-        let result = if req.timeout_nano == 0 {
-            rx.recv().map_err(err_to_others_err!(
-                e,
-                "Receive packet from Receiver error: "
-            ))?
-        } else {
-            rx.recv_timeout(Duration::from_nanos(req.timeout_nano as u64))
-                .map_err(err_to_others_err!(
-                    e,
-                    "Receive packet from Receiver timeout: "
-                ))?
-        };
+        let t = thread::spawn(move || {
+            let result = if req.timeout_nano == 0 {
+                rx.recv().map_err(err_to_others_err!(
+                        e,
+                        "Receive packet from Receiver error: "
+                        ))?
+            } else {
+                rx.recv_timeout(Duration::from_nanos(req.timeout_nano as u64))
+                    .map_err(err_to_others_err!(
+                            e,
+                            "Receive packet from Receiver timeout: "
+                            ))?
+            };
 
-        let buf = result?;
-        let res = Response::decode(buf).map_err(err_to_others_err!(e, "Unpack response error "))?;
+            let buf = result?;
+            let res = Response::decode(buf)
+                .map_err(err_to_others_err!(e, "Unpack response error "))?;
 
-        let status = res.status();
-        if status.code() != Code::OK {
-            return Err(Error::RpcStatus((*status).clone()));
-        }
+            let status = res.status();
+            if status.code() != Code::OK {
+                return Err(Error::RpcStatus((*status).clone()));
+            }
 
-        Ok(res)
+            Ok(res)
+        });
+
+        t.join().unwrap()
     }
 }
 


### PR DESCRIPTION
Calling Rust from a GCC destructor can result in panics when using pthreads (rust-lang/rust-28129). Move client request code to a separate thread to work around this issue.