### PR TITLE
ci: bump rust-toolchain to 1.95.0 and apply clippy --fix

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -724,9 +724,7 @@ pub fn gen(
             continue;
         }
 
-        results
-            .file
-            .extend(gen_file(file, &root_scope, customize).into_iter());
+        results.file.extend(gen_file(file, &root_scope, customize));
     }
 
     results

--- a/compiler/src/prost_codegen.rs
+++ b/compiler/src/prost_codegen.rs
@@ -16,7 +16,7 @@ use derive_new::new;
 use prost::Message;
 use prost_build::{protoc, protoc_include, Config, Method, Service, ServiceGenerator};
 use prost_types::FileDescriptorSet;
-use std::io::{Error, ErrorKind, Read};
+use std::io::{Error, Read};
 use std::path::Path;
 use std::{fs, io, process::Command};
 
@@ -53,10 +53,10 @@ where
 
     let output = cmd.output()?;
     if !output.status.success() {
-        return Err(Error::new(
-            ErrorKind::Other,
-            format!("protoc failed: {}", String::from_utf8_lossy(&output.stderr)),
-        ));
+        return Err(Error::other(format!(
+            "protoc failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )));
     }
 
     let mut buf = Vec::new();

--- a/compiler/src/util/mod.rs
+++ b/compiler/src/util/mod.rs
@@ -28,7 +28,7 @@ struct NameSpliter<'a> {
 }
 
 impl<'a> NameSpliter<'a> {
-    fn new(s: &str) -> NameSpliter {
+    fn new(s: &str) -> NameSpliter<'_> {
         NameSpliter {
             name: s.as_bytes(),
             pos: 0,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel="1.81.0"
+channel="1.95.0"
 profile="default"
 components=["rustfmt", "clippy"]

--- a/src/asynchronous/client.rs
+++ b/src/asynchronous/client.rs
@@ -95,7 +95,7 @@ impl Client {
             .map_err(|_| Error::LocalClosed)?;
 
         let result = if timeout_nano == 0 {
-            rx.recv().await.ok_or_else(|| Error::RemoteClosed)?
+            rx.recv().await.ok_or(Error::RemoteClosed)?
         } else {
             tokio::time::timeout(
                 std::time::Duration::from_nanos(timeout_nano as u64),
@@ -103,7 +103,7 @@ impl Client {
             )
             .await
             .map_err(|e| Error::Others(format!("Receive packet timeout {e:?}")))?
-            .ok_or_else(|| Error::RemoteClosed)?
+            .ok_or(Error::RemoteClosed)?
         };
 
         let msg = result?;

--- a/tests/run-examples.rs
+++ b/tests/run-examples.rs
@@ -1,3 +1,7 @@
+// wait_with_output is eventually called, but clippy can't see through the
+// branching cleanup paths and flags `wait_with_output("server", server)`.
+#![allow(clippy::zombie_processes)]
+
 use std::{
     io::{BufRead, BufReader},
     process::{Child, Command},

--- a/ttrpc-codegen/src/convert.rs
+++ b/ttrpc-codegen/src/convert.rs
@@ -38,7 +38,7 @@ trait ProtobufOptions {
     }
 }
 
-impl<'a> ProtobufOptions for &'a [model::ProtobufOption] {
+impl ProtobufOptions for &[model::ProtobufOption] {
     fn by_name(&self, name: &str) -> Option<&model::ProtobufConstant> {
         let option_name = name;
         for model::ProtobufOption { name, value } in *self {
@@ -359,10 +359,7 @@ impl<'a> LookupScope<'a> {
         current_path: &AbsolutePath,
         path: &RelativePath,
     ) -> Option<(AbsolutePath, MessageOrEnum)> {
-        let (first, rem) = match path.split_first_rem() {
-            Some(x) => x,
-            None => return None,
-        };
+        let (first, rem) = path.split_first_rem()?;
 
         if rem.is_empty() {
             match self.find_member(first) {

--- a/ttrpc-codegen/src/lib.rs
+++ b/ttrpc-codegen/src/lib.rs
@@ -265,13 +265,10 @@ impl<'a> Run<'a> {
         fs::File::open(fs_path)?.read_to_string(&mut content)?;
 
         let parsed = model::FileDescriptor::parse(content).map_err(|e| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                WithFileError {
-                    file: format!("{}", fs_path.display()),
-                    error: e.into(),
-                },
-            )
+            io::Error::other(WithFileError {
+                file: format!("{}", fs_path.display()),
+                error: e.into(),
+            })
         })?;
 
         for import_path in &parsed.import_paths {
@@ -286,13 +283,10 @@ impl<'a> Run<'a> {
         let descriptor =
             convert::file_descriptor(protobuf_path.to_owned(), &parsed, &this_file_deps).map_err(
                 |e| {
-                    io::Error::new(
-                        io::ErrorKind::Other,
-                        WithFileError {
-                            file: format!("{}", fs_path.display()),
-                            error: e.into(),
-                        },
-                    )
+                    io::Error::other(WithFileError {
+                        file: format!("{}", fs_path.display()),
+                        error: e.into(),
+                    })
                 },
             )?;
 
@@ -312,13 +306,10 @@ impl<'a> Run<'a> {
             }
         }
 
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            format!(
-                "protobuf path {:?} is not found in import path {:?}",
-                protobuf_path, self.includes
-            ),
-        ))
+        Err(io::Error::other(format!(
+            "protobuf path {:?} is not found in import path {:?}",
+            protobuf_path, self.includes
+        )))
     }
 
     fn add_fs_file(&mut self, fs_path: &Path) -> io::Result<String> {
@@ -334,13 +325,10 @@ impl<'a> Run<'a> {
                 self.add_file(&protobuf_path, fs_path)?;
                 Ok(protobuf_path)
             }
-            None => Err(io::Error::new(
-                io::ErrorKind::Other,
-                format!(
-                    "file {:?} must reside in include path {:?}",
-                    fs_path, self.includes
-                ),
-            )),
+            None => Err(io::Error::other(format!(
+                "file {:?} must reside in include path {:?}",
+                fs_path, self.includes
+            ))),
         }
     }
 }

--- a/ttrpc-codegen/src/parser.rs
+++ b/ttrpc-codegen/src/parser.rs
@@ -230,8 +230,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn lookahead_char_is_in(&self, alphabet: &str) -> bool {
-        self.lookahead_char()
-            .map_or(false, |c| alphabet.contains(c))
+        self.lookahead_char().is_some_and(|c| alphabet.contains(c))
     }
 
     fn next_char_opt(&mut self) -> Option<char> {
@@ -912,13 +911,7 @@ impl<'a> Parser<'a> {
 
     fn next_ident_if_in(&mut self, idents: &[&str]) -> ParserResult<Option<String>> {
         let v = match self.lookahead()? {
-            Some(Token::Ident(next)) => {
-                if idents.iter().any(|i| i == next) {
-                    next.clone()
-                } else {
-                    return Ok(None);
-                }
-            }
+            Some(Token::Ident(next)) if idents.iter().any(|i| i == next) => next.clone(),
             _ => return Ok(None),
         };
         self.advance()?;


### PR DESCRIPTION
## Why

CI is currently red for every PR: `cargo 1.81` (pinned in `rust-toolchain.toml`) can no longer resolve the checked-in `Cargo.lock`. Transitive deps such as `home v0.5.12` now require `edition2024` and `rustc >= 1.88`, neither available on 1.81. Every matrix leg (Check, Build, deny) fails at `cargo metadata` before it can do anything useful.

## What

1. Bump `rust-toolchain.toml` to `1.95.0` (current stable).
2. Apply `cargo clippy --fix` suggestions that newer clippy surfaces under `-D warnings`. All mechanical:
    - `io::Error::new(ErrorKind::Other, ...)` -> `io::Error::other(...)`
    - `.map_or(false, ...)` -> `.is_some_and(...)`
    - `.ok_or_else(|| lit)` -> `.ok_or(lit)`
    - Unnecessary explicit lifetimes (`foo<'a>` -> `foo<'_>`)
    - Redundant `.into_iter()` on an `IntoIterator` argument
    - A couple of `match Some/None -> return None` reductions to `?` / if-let-guard
3. Add a narrow `#![allow(clippy::zombie_processes)]` to `tests/run-examples.rs`. The lint is a false positive; `wait_with_output` is called on every cleanup path, clippy just cannot see through the control flow.

No behavior change.

## Verified locally

`make check-all`, `make`, `make -C compiler`, `make -C ttrpc-codegen`, `make -C example build-examples` all pass.

## Note

Advertised MSRV in `Cargo.toml` (`rust-version = "1.70"`) is unchanged. That's a promise to crate consumers and is independent of the toolchain the repo uses to build itself.
