### PR TITLE
feat: add accept method (supersedes #292)

### DIFF
--- a/src/asynchronous/server.rs
+++ b/src/asynchronous/server.rs
@@ -171,6 +171,15 @@ impl Server {
         Ok(())
     }
 
+    pub async fn accept(&self, conn: Socket) -> std::io::Result<()> {
+        let delegate = ServerBuilder {
+            services: self.services.clone(),
+            streams: Arc::default(),
+            shutdown_waiter: self.shutdown.subscribe(),
+        };
+        Connection::new(conn, delegate).run().await
+    }
+
     pub async fn shutdown(&mut self) -> Result<()> {
         self.stop_listen().await;
         self.disconnect().await;


### PR DESCRIPTION
Add accept method for better error handling and ergononics when only one connection is expected. Fixes #293

I didn't want to force push on a branch that is already used externally, but this branch removes the `&mut self` in favor of a `&self`.