### PR TITLE
ci: declare workflow-level `contents: read` on 1 workflows

### DIFF
--- a/.github/workflows/bvt.yml
+++ b/.github/workflows/bvt.yml
@@ -1,5 +1,9 @@
 name: BVT
 on: [pull_request]
+
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 1 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

Left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Best declared by a maintainer: `sanity.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.